### PR TITLE
Update README.md - Reddit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Yet another myth to dispel**: I've seen in many places lately the following assertion ([example](https://fr.reddit.com/r/AskReddit/comments/35s2je/whats_a_product_that_everybody_uses_but_nobody/cr7h8l6)):
+**Yet another myth to dispel**: I've seen in many places lately the following assertion ([example](https://np.reddit.com/r/AskReddit/comments/35s2je/whats_a_product_that_everybody_uses_but_nobody/cr7h8l6)):
 
 > ublock blocks ads just like adblock plus, but triggers the ads API to think it got viewed
 


### PR DESCRIPTION
The purpose of this small edit ( fr.reddit.com --> np.reddit.com in the "Yet another myth to dispel" URL) is so that the user isn't redirected to the French "version" of Reddit, but to the English, Read-Only (No voting, etc) "version" of the site. np.reddit.com is usually used when being linked to by other subreddits or other sites, such as this.

Thank you very much for your time!
