### PR TITLE
Add strict blocking of softonic.com and 01net.com

### DIFF
--- a/assets/ublock/filters.txt
+++ b/assets/ublock/filters.txt
@@ -103,3 +103,12 @@ deviantart.com##.dp-ad-chrome.dp-ad-visible
 # Using `other` will cause the whole site to be blocked through strict blocking,
 # yet the site will render properly if a user still decide to go ahead.
 ||sourceforge.net^$other
+
+# https://www.trustpilot.com/review/www.softonic.com
+# http://www.intego.com/mac-security-blog/another-problematic-softonic-installer-brings-adware/
+# http://www.thesafemac.com/installmac-uninstaller-antics/
+||softonic.com^$other
+
+# http://www.lesnumeriques.com/appli-logiciel/telecharger-depuis-01net-nuit-gravement-a-sante-pc-n26763.html
+# http://www.journaldunet.com/solutions/dsi/des-malwares-sur-telecharger-com-01net-1012.shtml
+||www.01net.com^$other


### PR DESCRIPTION
Hi,

Softonic.com and 01net.com are software download portals having quite the same issues as Sourceforge.net.

So, I added strict blocking for Softonic.com and 01net.com.

But I got a question. Softonic.com is a 100% adware platform but not 01net.com. The adware platform of 01net.com is located in a category: www.01net.com/telecharger/ ; because 01net is also an online newspaper, is that possible to block strictly only the category instead of the whole domain with ||www.01net.com^$other ? If it's possible, I'll edit my commit.

Thanks in advance,
