### PR TITLE
sourceforge already moved to badware.txt

### DIFF
--- a/assets/ublock/filters.txt
+++ b/assets/ublock/filters.txt
@@ -97,10 +97,3 @@ deviantart.com##.dp-ad-chrome.dp-ad-visible
 
 # https://github.com/chrisaljoudi/uBlock/issues/1013
 ||mac-system-alert.com^
-
-# http://libregraphicsworld.org/blog/entry/anatomy-of-sourceforge-gimp-controversy
-# https://blog.l0cal.com/2015/06/02/what-happened-to-sourceforge/
-# http://blog.tedd.no/2014/11/25/sourceforge-malware/
-# Using `other` will cause the whole site to be blocked through strict blocking,
-# yet the site will render properly if a user still decide to go ahead.
-||sourceforge.net^$other


### PR DESCRIPTION
so it can be removed from the common filters
