### PR TITLE
Changed default Polish filters list to secured (https) version.

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -148,7 +148,7 @@
         "off": true,
         "title": "POL: Adblock polskie reguly",
         "group": "regions",
-        "oldLocation": "raw.githubusercontent.com/adblockpolska/Adblock_PL_List/master/adblock_polska.txt"
+        "oldLocation": "raw.githubusercontent.com/adblockpolska/Adblock_PL_List/master/adblock_polska.txt",
         "supportURL": "http://www.certyficate.it"
         },
     "https://easylist-downloads.adblockplus.org/antiadblockfilters.txt": {

--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -144,11 +144,12 @@
         "title": "Basic tracking list by Disconnect",
         "group": "privacy"
         },
-    "http://www.certyficate.it/adblock/adblock.txt": {
+    "https://www.certyficate.it/adblock/adblock.txt": {
         "off": true,
         "title": "POL: Adblock polskie reguly",
         "group": "regions",
         "oldLocation": "raw.githubusercontent.com/adblockpolska/Adblock_PL_List/master/adblock_polska.txt"
+        "supportURL": "http://www.certyficate.it"
         },
     "https://easylist-downloads.adblockplus.org/antiadblockfilters.txt": {
         "off": true,


### PR DESCRIPTION
For non-secure (http) version add this -> http://certyficate.it/adblock/adblock.txt <- to custom uBlock Origin's filters list.