### PR TITLE
use https for "POL: Adblock polskie reguly‎"

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -144,7 +144,7 @@
         "title": "Basic tracking list by Disconnect",
         "group": "privacy"
         },
-    "http://www.certyficate.it/adblock/adblock.txt": {
+    "https://www.certyficate.it/adblock/adblock.txt": {
         "off": true,
         "title": "POL: Adblock polskie reguly",
         "group": "regions",


### PR DESCRIPTION
www.certyficate.it supports https now.

See:
https://www.ssllabs.com/ssltest/analyze.html?d=certyficate.it