### PR TITLE
try/catch createShadowRoot in contentscripts

### DIFF
--- a/src/js/contentscript-end.js
+++ b/src/js/contentscript-end.js
@@ -470,7 +470,12 @@ var uBlockCollapser = (function() {
             if ( shadow !== null && shadow.className === sessionId ) {
                 continue;
             }
-            shadow = elem.createShadowRoot();
+            // not all nodes can be shadowed
+            try {
+                shadow = elem.createShadowRoot();
+            } catch (ex) {
+                continue;
+            }
             shadow.className = sessionId;
         }
     };

--- a/src/js/contentscript-start.js
+++ b/src/js/contentscript-start.js
@@ -181,7 +181,12 @@ var hideElements = function(selectors) {
         if ( shadow !== null && shadow.className === sessionId ) {
             continue;
         }
-        shadow = elem.createShadowRoot();
+            // not all nodes can be shadowed
+            try {
+                shadow = elem.createShadowRoot();
+            } catch (ex) {
+                continue;
+            }
         shadow.className = sessionId;
     }
 };


### PR DESCRIPTION
Currently, the contentscripts throw an error when trying to call createShadowRoot on certain elements (iframes etc).