### PR TITLE
fix https://github.com/chrisaljoudi/uBlock/issues/1520

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -7,7 +7,8 @@
     "adblock.schack.dk/block.txt": {
         "off": true,
         "title": "DNK: Schacks Adblock Plus liste",
-        "group": "regions"
+        "group": "regions",
+        "homeURL": "https://adblock.schack.dk/block.txt"
         },
     "dl.dropboxusercontent.com/u/1289327/abpxfiles/filtri.txt": {
         "off": true,


### PR DESCRIPTION
undoes https://github.com/chrisaljoudi/uBlock/commit/3248b8d27c0308ef54de8a90e74f35c5d1d507fd because `@@googleads.g.doubleclick.net` is no longer in the latest list