### PR TITLE
Added Conkeror to the list of supported platforms.

### DIFF
--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -13,7 +13,7 @@
         <bootstrap>true</bootstrap>
         <multiprocessCompatible>true</multiprocessCompatible>
         <optionsType>2</optionsType>
-{localized}
+	{localized}
 
         <!-- Firefox -->
         <targetApplication>
@@ -51,13 +51,13 @@
             </r:Description>
         </targetApplication>
 
-	<!-- Conkeror -->
-	<targetApplication>
-	  <Description>
-	      <id>{a79fe89b-6662-4ff4-8e88-09950ad4dfde}</id>
-	      <minVersion>0.1</minVersion>
-	      <maxVersion>9.9</maxVersion>
-	  </Description>
-	</targetApplication>
+        <!-- Conkeror -->
+        <targetApplication>
+            <r:Description>
+		<id>{a79fe89b-6662-4ff4-8e88-09950ad4dfde}</id>
+		<minVersion>0.1</minVersion>
+		<maxVersion>9.9</maxVersion>
+            </r:Description>
+        </targetApplication>
     </r:Description>
 </r:RDF>

--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -54,7 +54,7 @@
         <!-- Conkeror -->
         <targetApplication>
             <r:Description>
-		<id>{a79fe89b-6662-4ff4-8e88-09950ad4dfde}</id>
+		<id>{{a79fe89b-6662-4ff4-8e88-09950ad4dfde}}</id>
 		<minVersion>0.1</minVersion>
 		<maxVersion>9.9</maxVersion>
             </r:Description>

--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -50,5 +50,14 @@
                 <maxVersion>26.*</maxVersion>
             </r:Description>
         </targetApplication>
+
+	<!-- Conkeror -->
+	<targetApplication>
+	  <Description>
+	      <id>{a79fe89b-6662-4ff4-8e88-09950ad4dfde}</id>
+	      <minVersion>0.1</minVersion>
+	      <maxVersion>9.9</maxVersion>
+	  </Description>
+	</targetApplication>
     </r:Description>
 </r:RDF>


### PR DESCRIPTION
uBlock Origins runs well in [Conkeror](http://conkeror.org), an emacs-inspired browser. This
patch makes it possible to install the plugin directly, without having
to modify the install.rdf file.