### PR TITLE
Added basic Thunderbird support

### DIFF
--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -59,5 +59,14 @@
                 <maxVersion>9.9</maxVersion>
             </r:Description>
         </targetApplication>
+
+        <!-- Thunderbird -->
+        <targetApplication>
+            <r:Description>
+                <id>{{3550f703-e582-4d05-9a08-453d09bdfdc6}}</id>
+                <minVersion>38.3</minVersion>
+                <maxVersion>45.0</maxVersion>
+            </r:Description>
+        </targetApplication>
     </r:Description>
 </r:RDF>


### PR DESCRIPTION
This is **basic** Thunderbird support.

I just fixed as much as needed to get zero errors in error console. I guess the fact, that "watching for tab changes" works completely different in Thunderbird, protects me from having to do more to get a basic compatibility ;)

Working:
- Blocking itself (worked right from the start even without changes)
- Opening of new *content* tabs (to be able to actually open Dashboard and Logger)
- Dashboard and Logger are fully working. So it actually is possible to do settings. Both have to be opened from the Addons manager

NOT working:
- Icon for toolbar
- Integration with the browser

This is meant as a start and does well for my needs. It allows to block ads, tracking, social buttons, ... from content if Thunderbird is used as RSS reader. To get full support much more things would have to be changed as Thunderbird works completely different in many cases.