### PR TITLE
Add YousList as a Korean third party filter

### DIFF
--- a/assets/checksums.txt
+++ b/assets/checksums.txt
@@ -5,7 +5,7 @@
 146704ad1c0393e342afdb416762c183 assets/ublock/badware.txt
 7793a25fee903eb869984d728cb1920c assets/ublock/redirect.txt
 d6f734c851d5077bd545d0fa39e8bb8d assets/ublock/experimental.txt
-e1a6bb625a9ee59cc57f6b77c76108ff assets/ublock/filter-lists.json
+499c2168ce45f701052902adb85bb742 assets/ublock/filter-lists.json
 f549ce62117ff04b63c177227b5cb288 assets/thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt
 da709032e6b674de08b7561e3f4e552d assets/thirdparties/easylist-downloads.adblockplus.org/easylist.txt
 7f0443f3dcc9abfd47cfbc95ce824ddb assets/thirdparties/mirror1.malwaredomains.com/files/README.md

--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -164,6 +164,12 @@
         "group": "regions",
         "supportURL": "https://github.com/liamja/Prebake"
         },
+    "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt": {
+        "off": true,
+        "title": "KOR: YousList",
+        "group": "regions",
+        "supportURL": "https://github.com/yous/YousList"
+        },
     "https://liste-ar-adblock.googlecode.com/hg/Liste_AR.txt": {
         "off": true,
         "title": "ara: Liste AR",


### PR DESCRIPTION
Hi, I'm an author of [YousList](https://github.com/yous/YousList), which is a Korean adblock filter. I want to add this filter in the third-party filters settings page of uBlock.

This filter has 1,098 items:
![screenshot 2015-12-08 15 03 05](https://cloud.githubusercontent.com/assets/853977/11649241/46acb4c2-9dc0-11e5-808c-ab648de331e3.png)
and [keeps on updating](https://github.com/yous/YousList/commits/master). I couldn't find some guides for adding a third-party filter to this project, so if I did something wrong, please let me know.