### PR TITLE
Check responseHeaders length before calling pop()

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -2108,7 +2108,7 @@ var httpObserver = {
             return;
         }
 
-        if ( result.responseHeaders ) {
+        if ( result.responseHeaders && result.responseHeaders.length ) {
             channel.setResponseHeader(
                 'Content-Security-Policy',
                 result.responseHeaders.pop().value,


### PR DESCRIPTION
This throws an error on Firefox when responseHeaders is 0-length

![screen shot 2016-06-20 at 6 37 11 pm](https://cloud.githubusercontent.com/assets/737638/16191652/ef518e2c-3717-11e6-9699-802e10f606ac.png)

There is probably a better fix to be made here, but requires larger changes