### PR TITLE
Add vivaldi-scheme as a default in Whitelist

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -79,6 +79,7 @@ return {
         'chrome-scheme',
         'loopconversation.about-scheme',
         'opera-scheme',
+        'vivaldi-scheme',
         ''
     ].join('\n').trim(),
 


### PR DESCRIPTION
Vivaldi is another browser based on Blink that supports uBlock. Adding its scheme in the default whitelisting would prevent any issue with it.