### PR TITLE
Update filter-lists.json with more cookie rules

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -197,6 +197,12 @@
 		"group": "regions",
 		"supportURL": "https://github.com/liamja/Prebake"
 	},
+	"http://www.kiboke-studio.hr/i-dont-care-about-cookies/abp/": {
+		"off": true,
+		"title": "I don't care about cookies‎",
+		"group": "regions",
+		"supportURL": "http://www.kiboke-studio.hr/i-dont-care-about-cookies/"
+	},
 	"https://raw.githubusercontent.com/yous/YousList/master/youslist.txt": {
 		"off": true,
 		"title": "KOR: YousList",


### PR DESCRIPTION
Additional addons bloat and slow down your browser, which is why adding new filter lists to uBlock is the best way.

However one of the best filter lists for European citizens is sadly not in uBlock by default. Removing terribly obtrusive cookie warnigs from 10000+ websites rather than just the <1000 that uBlock can block by default.

Dear Raymond, please consider my pull request. It will help more people in using and especially finding this list without the need of an additional addon.

Kind regards!

**PPS:** I know you can _manually_ add it, but it should be in there by default

>Addon:
>https://addons.mozilla.org/de/firefox/addon/i-dont-care-about-cookies/
>
>Website:
>http://www.kiboke-studio.hr/i-dont-care-about-cookies/
>
>Filter list:
>http://www.kiboke-studio.hr/i-dont-care-about-cookies/abp/