### PR TITLE
Support back button navigation on Android

### DIFF
--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -1000,7 +1000,8 @@ vAPI.tabs.open = function(details) {
 
     if ( vAPI.fennec ) {
         tabBrowser.addTab(details.url, {
-            selected: details.active !== false
+            selected: details.active !== false,
+            parentId: tabBrowser.selectedTab.id
         });
         // Note that it's impossible to move tabs on Fennec, so don't bother
         return;


### PR DESCRIPTION
Steps to reproduce:
1. Open a new tab through uBlock in Fennec/Firefox for Android (either the config popup from the main menu, or the dashboard from the popup itself)
2. Press the back button.

Observed:
The new tab remains open, instead Firefox as a whole disappears into the background.

Expected:
The new tab should close, returning me to the previous tab.

Solution:
When opening a new tab in Fennec, we should pass the ID (Firefox's internal ID, not the one used by uBlock) of the current tab as an additional parentId parameter to addTab.