### PR TITLE
Do not assume cloud support

### DIFF
--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -650,6 +650,15 @@ var µb = µBlock;
 /******************************************************************************/
 
 var onMessage = function(request, sender, callback) {
+    if (vAPI.cloud === undefined) {
+        switch ( request.what ) {
+        case 'cloudSupported':
+            return false;
+        default:
+            break;
+        }
+        return
+    }
     // Async
     switch ( request.what ) {
     case 'cloudGetOptions':
@@ -668,6 +677,9 @@ var onMessage = function(request, sender, callback) {
 
     case 'cloudPush':
         return vAPI.cloud.push(request.datakey, request.data, callback);
+
+    case 'cloudSupported':
+        return true;
 
     default:
         break;

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -219,11 +219,29 @@ var onUserSettingsReceived = function(details) {
     uDom('#restoreFilePicker').on('change', handleImportFilePicker);
 };
 
+var onCloudSupportReceived = function(isSupported) {
+    // Only disable when support is explicitly set to false
+    if ( isSupported === false ) {
+        // Force disabling of cloud storage if enabled previously
+        messaging.send(
+            'dashboard',
+            {
+                what: 'userSettings',
+                name: "cloudStorageEnabled",
+                value: false
+            }
+        );
+        uDom.nodeFromId('cloud-storage-enabled').disabled = true;
+        uDom.nodeFromSelector('#cloud-storage-enabled ~ .fa.info').title = "Cloud sync not supported in this browser";
+    }
+}
+
 /******************************************************************************/
 
 uDom.onLoad(function() {
     messaging.send('dashboard', { what: 'userSettings' }, onUserSettingsReceived);
     messaging.send('dashboard', { what: 'getLocalData' }, onLocalDataReceived);
+    messaging.send('cloudWidget', { what: 'cloudSupported' }, onCloudSupportReceived);
 });
 
 /******************************************************************************/

--- a/src/js/start.js
+++ b/src/js/start.js
@@ -67,12 +67,14 @@ var onAllReady = function() {
     // for launch time.
     µb.assets.remoteFetchBarrier -= 1;
 
-    vAPI.cloud.start([
-        'tpFiltersPane',
-        'myFiltersPane',
-        'myRulesPane',
-        'whitelistPane'
-    ]);
+    if (vAPI.cloud !== undefined || !vAPI.cloud) {
+        vAPI.cloud.start([
+            'tpFiltersPane',
+            'myFiltersPane',
+            'myRulesPane',
+            'whitelistPane'
+        ]);
+    }
 
     //quickProfiler.stop(0);
 


### PR DESCRIPTION
Re: [uBlock-edge PR#13](https://github.com/nikrolls/uBlock-Edge/pull/13)
Proposing the following to not assume cloud support and disable setting when `vAPI.cloud` is not defined in `vapi-background.js`.

Feedback is appreciated.