### PR TITLE
Prevent possible error when a node has no children

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -1086,7 +1086,7 @@ vAPI.domCollapser = (function() {
             if ( node.localName === 'iframe' ) {
                 addIFrame(node);
             }
-            if ( node.children.length !== 0 ) {
+            if ( node.children && node.children.length !== 0 ) {
                 var iframes = node.getElementsByTagName('iframe');
                 if ( iframes.length !== 0 ) {
                     addIFrames(iframes);


### PR DESCRIPTION
Compat with Edge; SVG nodes don't have a `children` property and therefore this throws an error whenever an SVG is added, removed or moved in the DOM.