### PR TITLE
Adblock the NSA

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -359,5 +359,11 @@
 		"group": "regions",
 		"lang": "sl",
 		"supportURL": "https://github.com/betterwebleon/slovenian-list"
+	},
+	"https://raw.githubusercontent.com/gasull/adblock-nsa/master/filters.txt": {
+		"off": true,
+		"title": "Adblock the NSA",
+		"group": "privacy",
+		"supportURL": "https://github.com/gasull/adblock-nsa"
 	}
 }


### PR DESCRIPTION
Repository https://github.com/gasull/adblock-nsa
Filters to block NSA known servers from Shadow Brokers dump, https://twitter.com/MSwannMSFT/status/793002397052186626.