### PR TITLE
drop Conkeror from install.rdf

### DIFF
--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -52,15 +52,6 @@
             </r:Description>
         </targetApplication>
 
-        <!-- Conkeror -->
-        <targetApplication>
-            <r:Description>
-                <id>{{a79fe89b-6662-4ff4-8e88-09950ad4dfde}}</id>
-                <minVersion>0.1</minVersion>
-                <maxVersion>9.9</maxVersion>
-            </r:Description>
-        </targetApplication>
-
         <!-- Thunderbird -->
         <targetApplication>
             <r:Description>


### PR DESCRIPTION
Since #1356 has been declined.

Debian is currently carrying this pull request as a patch, and it would be good if it was merged upstream now that it has been decided that Conkeror support will not happen.

Thanks.