### PR TITLE
Use RegExp.test and String.startsWith when possible

### DIFF
--- a/platform/chromium/vapi-background.js
+++ b/platform/chromium/vapi-background.js
@@ -956,7 +956,7 @@ vAPI.net.registerListeners = function() {
             // Still need this because often behind-the-scene requests are wrongly
             // categorized as 'other'
             var imageExtensions = /\.(?:ico|png|gif|jpg|jpeg|webp)$/;
-            if ( mediaExtensions.test(needle) ) {
+            if ( imageExtensions.test(needle) ) {
                 details.type = 'image';
                 return;
             }

--- a/platform/chromium/vapi-background.js
+++ b/platform/chromium/vapi-background.js
@@ -294,7 +294,7 @@ vAPI.tabs.registerListeners = function() {
         var pos = url.indexOf(',');
         if ( pos === -1 ) { return url; }
         var s = url.slice(0, pos);
-        if ( s.search(/\s/) === -1 ) { return url; }
+        if ( !/\s/.test(s) ) { return url; }
         return s.replace(/\s+/, '') + url.slice(pos);
     };
 
@@ -940,20 +940,23 @@ vAPI.net.registerListeners = function() {
         // If no transposition possible, transpose to `object` as per
         // Chromium bug 410382 (see below)
         if ( pos !== -1 ) {
-            var needle = path.slice(pos) + '.';
-            if ( '.eot.ttf.otf.svg.woff.woff2.'.indexOf(needle) !== -1 ) {
+            var needle = path.slice(pos);
+            var fontExtensions = /\.(?:eot|ttf|otf|svg|woff|woff2)$/;
+            if ( fontExtensions.test(needle) ) {
                 details.type = 'font';
                 return;
             }
 
-            if ( '.mp3.mp4.webm.'.indexOf(needle) !== -1 ) {
+            var mediaExtensions = /\.(?:mp3|mp4|webm)$/;
+            if ( mediaExtensions.test(needle) ) {
                 details.type = 'media';
                 return;
             }
 
             // Still need this because often behind-the-scene requests are wrongly
             // categorized as 'other'
-            if ( '.ico.png.gif.jpg.jpeg.webp.'.indexOf(needle) !== -1 ) {
+            var imageExtensions = /\.(?:ico|png|gif|jpg|jpeg|webp)$/;
+            if ( mediaExtensions.test(needle) ) {
                 details.type = 'image';
                 return;
             }

--- a/platform/chromium/vapi-common.js
+++ b/platform/chromium/vapi-common.js
@@ -40,9 +40,10 @@ vAPI.setTimeout = vAPI.setTimeout || self.setTimeout.bind(self);
 // http://www.w3.org/International/questions/qa-scripts#directions
 
 var setScriptDirection = function(language) {
+    var rtlLanguages = /(?:ar|he|fa|ps|ur)/;
     document.body.setAttribute(
         'dir',
-        ['ar', 'he', 'fa', 'ps', 'ur'].indexOf(language) !== -1 ? 'rtl' : 'ltr'
+        rtlLanguages.test(language) ? 'rtl' : 'ltr'
     );
 };
 

--- a/platform/firefox/vapi-common.js
+++ b/platform/firefox/vapi-common.js
@@ -49,9 +49,10 @@ vAPI.setTimeout = vAPI.setTimeout || function(callback, delay, extra) {
 // http://www.w3.org/International/questions/qa-scripts#directions
 
 var setScriptDirection = function(language) {
+    var rtlLanguages = /(?:ar|he|fa|ps|ur)/;
     document.body.setAttribute(
         'dir',
-        ['ar', 'he', 'fa', 'ps', 'ur'].indexOf(language) !== -1 ? 'rtl' : 'ltr'
+        rtlLanguages.test(language) ? 'rtl' : 'ltr'
     );
 };
 

--- a/platform/safari/vapi-background.js
+++ b/platform/safari/vapi-background.js
@@ -44,7 +44,7 @@
 
     /******************************************************************************/
 
-    if(navigator.userAgent.indexOf("Safari/6") === -1) { // If we're not on at least Safari 8
+    if ( !/Safari\/6/.test(navigator.userAgent) ) { // If we're not on at least Safari 8
         var _open = XMLHttpRequest.prototype.open;
         XMLHttpRequest.prototype.open = function(m, u) {
             if(u.lastIndexOf("safari-extension:", 0) === 0) {

--- a/platform/safari/vapi-common.js
+++ b/platform/safari/vapi-common.js
@@ -34,9 +34,10 @@ var vAPI = self.vAPI = self.vAPI || {};
 // http://www.w3.org/International/questions/qa-scripts#directions
 
 var setScriptDirection = function(language) {
+    var rtlLanguages = /(?:ar|he|fa|ps|ur)/;
     document.body.setAttribute(
         'dir',
-        ['ar', 'he', 'fa', 'ps', 'ur'].indexOf(language) !== -1 ? 'rtl' : 'ltr'
+        rtlLanguages.test(language) ? 'rtl' : 'ltr'
     );
 };
 

--- a/src/js/1p-filters.js
+++ b/src/js/1p-filters.js
@@ -101,7 +101,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( !file.type.startsWith("test") ) {
+    if ( !file.type.startsWith("text") ) {
         return;
     }
     var fr = new FileReader();

--- a/src/js/1p-filters.js
+++ b/src/js/1p-filters.js
@@ -101,7 +101,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( !file.type.startsWith("text") ) {
+    if ( !file.type.startsWith('text') ) {
         return;
     }
     var fr = new FileReader();

--- a/src/js/1p-filters.js
+++ b/src/js/1p-filters.js
@@ -101,7 +101,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( file.type.indexOf('text') !== 0 ) {
+    if ( !file.type.startsWith("test") ) {
         return;
     }
     var fr = new FileReader();

--- a/src/js/cosmetic-filtering.js
+++ b/src/js/cosmetic-filtering.js
@@ -311,7 +311,7 @@ FilterParser.prototype.parse = function(raw) {
     // https://github.com/gorhill/httpswitchboard/issues/260
     // Any sequence of `#` longer than one means the line is not a valid
     // cosmetic filter.
-    if ( this.suffix.indexOf('##') !== -1 ) {
+    if ( /##/.test(this.suffix) ) {
         this.cosmetic = false;
         return this;
     }
@@ -796,7 +796,7 @@ FilterContainer.prototype.keyFromSelector = function(selector) {
     var matches = this.rePlainSelector.exec(selector);
     if ( matches === null ) { return; }
     var key = matches[0];
-    if ( key.indexOf('\\') === -1 ) {
+    if ( !/\\/.test(key) ) {
         return key;
     }
     key = '';
@@ -936,10 +936,10 @@ FilterContainer.prototype.compileGenericHideSelector = function(parsed, out) {
 
     // All else: high-high generics.
     // Distinguish simple vs complex selectors.
-    if ( selector.indexOf(' ') === -1 ) {
-        out.push('c\vhhsg0\v' + selector);
-    } else {
+    if ( / /.test(selector) ) {
         out.push('c\vhhcg0\v' + selector);
+    } else {
+        out.push('c\vhhsg0\v' + selector);
     }
 };
 

--- a/src/js/dyna-rules.js
+++ b/src/js/dyna-rules.js
@@ -131,7 +131,7 @@ function handleImportFilePicker() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( file.type.indexOf('text') !== 0 ) {
+    if ( !file.type.startsWith("text") ) {
         return;
     }
     var fr = new FileReader();

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -81,7 +81,7 @@ var safeTextToTagNode = function(text) {
 
 var safeTextToTextNode = function(text) {
     // TODO: remove once no more HTML entities in translation files.
-    if ( text.indexOf('&') !== -1 ) {
+    if ( /&/.test(text) ) {
         text = text.replace(/&ldquo;/g, '“')
                    .replace(/&rdquo;/g, '”')
                    .replace(/&lsquo;/g, '‘')
@@ -93,7 +93,7 @@ var safeTextToTextNode = function(text) {
 var safeTextToDOM = function(text, parent) {
     if ( text === '' ) { return; }
     // Fast path (most common).
-    if ( text.indexOf('<') === -1 ) {
+    if ( !/</.test(text) ) {
         return parent.appendChild(safeTextToTextNode(text));
     }
     // Slow path.
@@ -137,7 +137,7 @@ vAPI.i18n.render = function(context) {
             continue;
         }
         // TODO: remove once it's all replaced with <input type="...">
-        if ( text.indexOf('{') !== -1 ) {
+        if ( /{/.test(text) ) {
             text = text.replace(/\{\{input:([^}]+)\}\}/g, '<input type="$1">');
         }
         safeTextToDOM(text, elem);

--- a/src/js/logger-ui-inspector.js
+++ b/src/js/logger-ui-inspector.js
@@ -265,7 +265,7 @@ var selectorFromNode = function(node) {
             code = node.querySelector('code');
             if ( code !== null ) {
                 selector = code.textContent + ' > ' + selector;
-                if ( selector.indexOf('#') !== -1 ) {
+                if ( /#/.test(selector) ) {
                     break;
                 }
             }

--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -40,7 +40,7 @@ var getDomainNames = function(targets) {
     var target, domain;
     for ( var i = 0; i < targets.length; i++ ) {
         target = targets[i];
-        if ( target.indexOf('/') !== -1 ) {
+        if ( /\//.test(target) ) {
             domain = µburi.domainFromURI(target) || '';
         } else {
             domain = µburi.domainFromHostname(target) || target;
@@ -918,9 +918,9 @@ var untangleRules = function(s) {
         line = s.slice(lineBeg, lineEnd).trim();
         lineBeg = lineEnd + 1;
 
-        if ( line.indexOf('://') !== -1 ) {
+        if ( /:\/\//.test(line) ) {
             urlRules.push(line);
-        } else if ( line.indexOf(':') === -1 ) {
+        } else if ( !/:/.test(line) ) {
             firewallRules.push(line);
         } else {
             switches.push(line);

--- a/src/js/redirect-engine.js
+++ b/src/js/redirect-engine.js
@@ -37,10 +37,10 @@ var RedirectEntry = function() {
 
 RedirectEntry.prototype.toURL = function() {
     if ( this.data.startsWith('data:') === false ) {
-        if ( this.mime.indexOf(';') === -1 ) {
-            this.data = 'data:' + this.mime + ';base64,' + btoa(this.data);
-        } else {
+        if ( /;/.test(this.mime) ) {
             this.data = 'data:' + this.mime + ',' + this.data;
+        } else {
+            this.data = 'data:' + this.mime + ';base64,' + btoa(this.data);
         }
     }
     return this.data;

--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -786,7 +786,7 @@ var elementsFromSelector = function(selector, context) {
         context = document;
     }
     var out;
-    if ( selector.indexOf(':') !== -1 ) {
+    if ( /:/.test(selector) ) {
         out = elementsFromSpecialSelector(selector);
         if ( out !== undefined ) {
             return out;

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -38,7 +38,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( file.type.indexOf('text') !== 0 ) {
+    if ( !file.type.startsWith("text") ) {
         return;
     }
     var filename = file.name;

--- a/src/js/static-net-filtering.js
+++ b/src/js/static-net-filtering.js
@@ -266,7 +266,7 @@ var hostnameTestPicker = function(owner) {
     var domainOpt = owner.domainOpt;
 
     // Only one hostname
-    if ( domainOpt.indexOf('|') === -1 ) {
+    if ( !/|/.test(domainOpt) ) {
         if ( domainOpt.startsWith('~') ) {
             owner._notHostname = domainOpt.slice(1);
             return hostnameMissTest;
@@ -1361,7 +1361,7 @@ FilterParser.prototype.parse = function(raw) {
         if ( pos !== -1 ) {
             // https://github.com/gorhill/uBlock/issues/952
             // Discard Adguard-specific `$$` filters.
-            if ( s.indexOf('$$') !== -1 ) {
+            if ( /\$\$/.test(s) ) {
                 this.unsupported = true;
                 return this;
             }

--- a/src/js/ublock.js
+++ b/src/js/ublock.js
@@ -48,13 +48,13 @@ var isHandcraftedWhitelistDirective = function(directive) {
 
 var matchDirective = function(url, hostname, directive) {
     // Directive is a plain hostname.
-    if ( directive.indexOf('/') === -1 ) {
+    if ( !/\//.test(directive) ) {
         return hostname.endsWith(directive) &&
               (hostname.length === directive.length ||
                hostname.charAt(hostname.length - directive.length - 1) === '.');
     }
     // Match URL exactly.
-    if ( directive.startsWith('/') === false && directive.indexOf('*') === -1 ) {
+    if ( directive.startsWith('/') === false && !/\*/.test(directive) ) {
         return url === directive;
     }
     // Transpose into a regular expression.
@@ -219,7 +219,7 @@ var matchBucket = function(url, hostname, bucket, start) {
             directive = line;
         }
         // Plain hostname
-        else if ( line.indexOf('/') === -1 ) {
+        else if ( !/\//.test(line) ) {
             if ( reInvalidHostname.test(line) ) {
                 key = '#';
                 directive = '# ' + line;

--- a/src/js/udom.js
+++ b/src/js/udom.js
@@ -606,7 +606,7 @@ DOMList.prototype.removeClass = function(className) {
 /******************************************************************************/
 
 DOMList.prototype.toggleClass = function(className, targetState) {
-    if ( className.indexOf(' ') !== -1 ) {
+    if ( / /.test(className) ) {
         return this.toggleClasses(className, targetState);
     }
     var i = this.nodes.length;

--- a/src/js/url-net-filtering.js
+++ b/src/js/url-net-filtering.js
@@ -396,7 +396,7 @@ URLNetFiltering.prototype.fromString = function(text) {
         }
 
         // Coarse test
-        if ( line.indexOf('://') === -1 ) {
+        if ( !/:\/\//.test(line) ) {
             continue;
         }
 
@@ -406,7 +406,7 @@ URLNetFiltering.prototype.fromString = function(text) {
         }
 
         // Finer test
-        if ( fields[1].indexOf('://') === -1 ) {
+        if ( !/:\/\//.test(fields[1]) ) {
             continue;
         }
 

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -70,7 +70,7 @@ var handleImportFilePicker = function() {
     if ( file === undefined || file.name === '' ) {
         return;
     }
-    if ( file.type.indexOf('text') !== 0 ) {
+    if ( !file.type.startsWith("text") ) {
         return;
     }
     var fr = new FileReader();


### PR DESCRIPTION
RegExp.prototype.test is marginally more efficient than String.indexOf and String.search, so I used it when possible (i.e. binary comparisons, that would otherwise discard the result of indexOf/search). I did the same with String.startsWith vs `.indexOf === 0`.