### PR TITLE
Fixed 'a href' tag

### DIFF
--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -420,7 +420,7 @@
     "description":"English: List of your dynamic filtering rules."
   },
   "rulesFormatHint":{
-    "message":"Regelsyntaks: <code>kilde destination type handling<\/code> (<a href<a href='https:\/\/github.com\/gorhill\/uBlock\/wiki\/Dynamic-filtering:-rule-syntax'>Fuld dokumentation<\/a>).",
+    "message":"Regelsyntaks: <code>kilde destination type handling<\/code> (<a href='https:\/\/github.com\/gorhill\/uBlock\/wiki\/Dynamic-filtering:-rule-syntax'>Fuld dokumentation<\/a>).",
     "description":"English: dynamic rule syntax and full documentation."
   },
   "whitelistPrompt":{


### PR DESCRIPTION
There was a mistypo that cause uBlock to display (<a hrefFuld dokumentation) in danish language, on My Rules section