### PR TITLE
Align the nav-bar button more nicely in Pale Moon

### DIFF
--- a/platform/firefox/css/legacy-toolbar-button.css
+++ b/platform/firefox/css/legacy-toolbar-button.css
@@ -1,5 +1,6 @@
 ﻿#uBlock0-legacy-button {
     list-style-image: url('../img/browsericons/icon24.svg');
+    -moz-box-orient: inherit;
 }
 #uBlock0-legacy-button.off {
     list-style-image: url('../img/browsericons/icon24-off.svg');
@@ -43,4 +44,24 @@ toolbarpaletteitem #uBlock0-legacy-button[badge]::before {
 #uBlock0-legacy-button .toolbarbutton-menu-dropmarker {
     display: none;
     -moz-box-orient: horizontal;
+}
+
+/* Align the nav-bar button more nicely in Pale Moon */
+#nav-bar #uBlock0-legacy-button .toolbarbutton-menu-dropmarker {
+    display: inline;
+    visibility: hidden;
+    margin-left: -10px;
+}
+#nav-bar #uBlock0-legacy-button[badge]::before {
+    display: none;
+}
+#nav-bar #uBlock0-legacy-button[badge]::after {
+    background: #555;
+    color: #fff;
+    content: attr(badge);
+    font: bold 10px sans-serif;
+    margin-top: -2px;
+    margin-left: -18px;
+    padding: 0 2px;
+    position: fixed;
 }


### PR DESCRIPTION
This will remove ugly spacing around the button and relocate the badge, so it fills a gap after missing arrow.
This is effective only if the button is placed inside the nav-bar and it shouldn't break anything else. 

|   | Windows | Linux |
|---|---|---|
| **before** | ![img](http://i.imgur.com/0408K0i.png) | ![img](http://i.imgur.com/tLpPiOF.png) |
| **after** | ![img](http://i.imgur.com/ub9Ow6u.png) | ![img](http://i.imgur.com/R86YlHd.png) |