### PR TITLE
DOM Inspector: Fallback to .childNodes when .children not present

### DIFF
--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -834,6 +834,17 @@ var elementsFromSpecialSelector = function(selector) {
 
 /******************************************************************************/
 
+var getSvgRootChildren = function() {
+    if ( svgRoot.children ) {
+        return svgRoot.children;
+    } else {
+        var childNodes = Array.prototype.slice.apply(svgRoot.childNodes);
+        return childNodes.filter(function(node) {
+            return node.nodeType === Node.ELEMENT_NODE;
+        });
+    }
+};
+
 var highlightElements = function(scrollTo) {
     var wv = pickerRoot.contentWindow.innerWidth;
     var hv = pickerRoot.contentWindow.innerHeight;
@@ -842,6 +853,7 @@ var highlightElements = function(scrollTo) {
     var xl, xr, yt, yb, w, h, ws;
     var xlu = Number.MAX_VALUE, xru = 0, ytu = Number.MAX_VALUE, ybu = 0;
     var lists = highlightedElementLists;
+    var svgRootChildren = getSvgRootChildren();
 
     for ( var i = 0; i < lists.length; i++ ) {
         elems = lists[i];
@@ -881,7 +893,7 @@ var highlightElements = function(scrollTo) {
             if ( yt < ytu ) { ytu = yt; }
             if ( yb > ybu ) { ybu = yb; }
         }
-        svgRoot.children[i+1].setAttribute('d', islands.join('') || 'M0 0');
+        svgRootChildren[i+1].setAttribute('d', islands.join('') || 'M0 0');
     }
 
     svgRoot.firstElementChild.setAttribute('d', ocean.join(''));


### PR DESCRIPTION
When the browser does not support .children on the svgRoot element (MS Edge, for example), filter childNodes for elements and use that list instead.

Happy to take feedback on the implementation, or location of the helper function to match code style, etc.