### PR TITLE
Throw an actual Error object instead of a string

### DIFF
--- a/platform/safari/vapi-client.js
+++ b/platform/safari/vapi-client.js
@@ -282,7 +282,7 @@ open = function(u) {\
 return block(u, 'popup') ? null : wo.apply(this, arguments);\
 };\
 XMLHttpRequest.prototype.open = function(m, u) {\
-if(block(u, 'xmlhttprequest')) {throw 'InvalidAccessError'; return;}\
+if(block(u, 'xmlhttprequest')) {throw new Error('InvalidAccessError'); return;}\
 else {xo.apply(this, arguments); return;}\
 };";
         if(frameId === 0) {


### PR DESCRIPTION
Error objects have `stack` properties that can be passed to error reporting tools; strings do not. Helpful for use with open source error reporting tools like [Sentry](/getsentry/sentry).