### PR TITLE
link corrections

### DIFF
--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -1,10 +1,10 @@
 {
-	"http://adblock.gardar.net/is.abp.txt": {
+	"https://adblock.gardar.net/is.abp.txt": {
 		"off": true,
 		"title": "ISL: Icelandic ABP List",
 		"group": "regions",
 		"lang": "is",
-		"supportURL": "http://adblock.gardar.net/"
+		"supportURL": "https://adblock.gardar.net/"
 	},
 	"https://adblock.dk/block.csv": {
 		"off": true,
@@ -17,7 +17,7 @@
 		"off": true,
 		"title": "ITA: ABP X Files",
 		"group": "regions",
-		"supportURL": "http://noads.it/"
+		"supportURL": "https://noads.it/"
 	},
 	"https://adguard.com/en/filter-rules.html?id=1": {
 		"off": true,
@@ -44,7 +44,7 @@
 		"group": "regions",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=102"
 	},
-	"easylist-downloads.adblockplus.org/easylist.txt": {
+	"https://easylist-downloads.adblockplus.org/easylist.txt": {
 		"title": "EasyList",
 		"group": "ads",
 		"homeURL": "https://easylist.to/easylist/easylist.txt",
@@ -96,7 +96,7 @@
 		"lang": "it",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=96"
 	},
-	"easylist-downloads.adblockplus.org/easyprivacy.txt": {
+	"https://easylist-downloads.adblockplus.org/easyprivacy.txt": {
 		"title": "EasyPrivacy",
 		"group": "privacy",
 		"homeURL": "https://easylist.to/easylist/easyprivacy.txt",
@@ -128,11 +128,11 @@
 		"lang": "lv",
 		"supportURL": "https://notabug.org/latvian-list/adblock-latvian"
 	},
-	"http://hosts-file.net/.%5Cad_servers.txt": {
+	"https://hosts-file.net/.%5Cad_servers.txt": {
 		"off": true,
 		"title": "hpHosts’ Ad and tracking servers",
 		"group": "multipurpose",
-		"supportURL": "http://hosts-file.net/"
+		"supportURL": "https://hosts-file.net/"
 	},
 	"http://adblock.ee/list.php": {
 		"off": true,
@@ -161,7 +161,7 @@
 		"title": "POL: polskie filtry do Adblocka i uBlocka",
 		"group": "regions",
 		"lang": "pl",
-		"supportURL": "http://www.certyficate.it/adblock-ublock-polish-filters/"
+		"supportURL": "https://www.certyficate.it/adblock-ublock-polish-filters/"
 	},
 	"https://easylist-downloads.adblockplus.org/antiadblockfilters.txt": {
 		"off": true,
@@ -169,12 +169,12 @@
 		"group": "ads",
 		"supportURL": "https://forums.lanik.us/"
 	},
-	"http://adb.juvander.net/Finland_adb.txt": {
+	"https://adb.juvander.net/Finland_adb.txt": {
 		"off": true,
 		"title": "FIN: Finnish Addition to Easylist",
 		"group": "regions",
 		"lang": "fi",
-		"supportURL": "http://www.juvander.fi/AdblockFinland"
+		"supportURL": "https://www.juvander.fi/AdblockFinland"
 	},
 	"https://raw.githubusercontent.com/gfmaster/adblock-korea-contrib/master/filter.txt": {
 		"off": true,
@@ -228,15 +228,15 @@
 		"off": true,
 		"title": "Malware domains (long-lived)",
 		"group": "malware",
-		"supportURL": "http://www.malwaredomains.com/"
+		"supportURL": "https://www.malwaredomains.com/"
 	},
-	"mirror1.malwaredomains.com/files/justdomains": {
+	"https://mirror1.malwaredomains.com/files/justdomains": {
 		"title": "Malware domains",
 		"group": "malware",
 		"homeURL": "https://mirror.cedia.org.ec/malwaredomains/justdomains",
-		"supportURL": "http://www.malwaredomains.com/"
+		"supportURL": "https://www.malwaredomains.com/"
 	},
-	"pgl.yoyo.org/as/serverlist": {
+	"https://pgl.yoyo.org/as/serverlist": {
 		"title": "Peter Lowe’s Ad and tracking server list",
 		"group": "multipurpose",
 		"homeURL": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext",
@@ -282,12 +282,12 @@
 		"group": "malware",
 		"supportURL": "http://www.spam404.com/"
 	},
-	"http://stanev.org/abp/adblock_bg.txt": {
+	"https://stanev.org/abp/adblock_bg.txt": {
 		"off": true,
 		"title": "BGR: Bulgarian Adblock list",
 		"group": "regions",
 		"lang": "bg",
-		"supportURL": "http://stanev.org/abp/"
+		"supportURL": "https://stanev.org/abp/"
 	},
 	"http://winhelp2002.mvps.org/hosts.txt": {
 		"off": true,
@@ -337,7 +337,7 @@
 		"off": true,
 		"title": "TUR: Adguard Turkish Filter (obsolete, will be removed)",
 		"group": "regions",
-		"supportURL": "http://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
+		"supportURL": "https://forum.adguard.com/forumdisplay.php?51-Filter-Rules"
 	},
 	"https://filters.adtidy.org/extension/chromium/filters/13.txt": {
 		"off": true,
@@ -353,7 +353,7 @@
 		"lang": "vi",
 		"supportURL": "https://forums.lanik.us/"
 	},
-	"www.malwaredomainlist.com/hostslist/hosts.txt": {
+	"https://www.malwaredomainlist.com/hostslist/hosts.txt": {
 		"title": "Malware Domain List",
 		"group": "malware",
 		"homeURL": "https://www.malwaredomainlist.com/hostslist/hosts.txt"

--- a/platform/firefox/options.xul
+++ b/platform/firefox/options.xul
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" ?>
-<vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+<vbox xmlns="https://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<setting type="control">
 		<vbox>
 		<button id="showDashboardButton"/>


### PR DESCRIPTION
moved more links to https

moved adblock.ee back to http because it has a bad certificate or no certificate

http://pgl.yoyo.org/as/serverlist is down - https://pgl.yoyo.org/as/serverlist.php?showintro=0;hostformat=hosts should be the right one