### PR TITLE
Prevents back button from looping block page

### DIFF
--- a/src/js/document-blocked.js
+++ b/src/js/document-blocked.js
@@ -272,8 +272,8 @@ uDom.nodeFromId('why').textContent = details.fs;
 
 /******************************************************************************/
 
-if ( window.history.length > 1 ) {
-    uDom('#back').on('click', function() { window.history.back(); });
+if ( window.history.length > 2 ) {
+    uDom('#back').on('click', function() { window.history.go(-2); });
     uDom('#bye').css('display', 'none');
 } else {
     uDom('#bye').on('click', function() { window.close(); });


### PR DESCRIPTION
When the browser blocks navigation due to a strict rule, the "back" button merely navigates to the page that was blocked.

This does not appear to be intended because the other buttons that disable blocking on that URL direct the browser to the URL. Therefore the back button must be intended to return the user to the page they were on _before_ they navigated to the blocked page.

This commit causes the browser to no longer navigate back to the redirect URL, but to navigate to the actual previous page, if possible. If the URL was typed into a fresh tab, the only reasonable option would be to disable blocking or close tab, so the close button would be displayed instead.
Currently, a dysfunctional "back" button is displayed in either case.