### PR TITLE
Check childElementCount in domChangedHandler().

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -1232,7 +1232,7 @@ vAPI.domCollapser = (function() {
             if ( node.localName === 'iframe' ) {
                 addIFrame(node);
             }
-            if ( node.children && node.children.length !== 0 ) {
+            if ( node.childElementCount > 0 ) {
                 var iframes = node.getElementsByTagName('iframe');
                 if ( iframes.length !== 0 ) {
                     addIFrames(iframes);


### PR DESCRIPTION
In Gecko, childElementCount is implemented as Children()->Length(), still performing allocation, but avoiding re-entering the DOM.