### PR TITLE
Adds support for the conkeror web browser

### DIFF
--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -51,6 +51,15 @@
                 <em:maxVersion>27.*</em:maxVersion>
             </Description>
         </em:targetApplication>
+        
+        <!-- Conkeror -->
+	    <em:targetApplication>
+	        <Description>
+                <em:id>{a79fe89b-6662-4ff4-8e88-09950ad4dfde}</em:id>
+                <em:minVersion>0.1</em:minVersion>
+                <em:maxVersion>9.9</em:maxVersion>
+	        </Description>
+	    </em:targetApplication> 
 
         <!-- Thunderbird -->
         <em:targetApplication>


### PR DESCRIPTION
This small change allows uBlock0 to be added to the conkeror webbrowser using M-x extensions interface "Install Add-on from file". Note that this gist is helpful in using the interface: https://gist.github.com/jsrjenkins/8af7ea18ae66b29abb4e827011726a4a and one should have 'session_pref("xpinstall.whitelist.required", false);' somewhere in your .conkerorrc to allow installation of unverified extensions.