### PR TITLE
Add instruction for Ru AdList

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -542,7 +542,8 @@
 		"title": "RUS: RU AdList (Дополнительная региональная подписка)",
 		"lang": "be ru uk",
 		"contentURL": "https://easylist-downloads.adblockplus.org/advblock.txt",
-		"supportURL": "https://forums.lanik.us/viewforum.php?f=102"
+		"supportURL": "https://forums.lanik.us/viewforum.php?f=102",
+		"instructionURL": "https://forums.lanik.us/viewtopic.php?f=102&t=22512"
 	},
 	"RUS-1": {
 		"content": "filters",


### PR DESCRIPTION
Ru AdList has many additions to block ads, counters, annoyances, anti-adblock warnings in Russian websites. This page contains the guide to all of them.