### PR TITLE
Norwegian filter list

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -515,6 +515,15 @@
 		"contentURL": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=100"
 	},
+		"NOR-0": {
+		"content": "filters",
+		"group": "regions",
+		"off": true,
+		"title": "Dandelion Sprouts liste for ryddigere nettsider",
+		"lang": "nb",
+		"contentURL": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ExperimentalNorwegianList.txt",
+		"supportURL": "https://github.com/DandelionSprout/adfilt/issues"
+	},
 	"POL-0": {
 		"content": "filters",
 		"group": "regions",

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -515,11 +515,11 @@
 		"contentURL": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=100"
 	},
-		"NOR-0": {
+	"NOR-0": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "Dandelion Sprouts liste for ryddigere nettsider",
+		"title": "Dandelion Sprouts norske filtre for ryddigere nettsider",
 		"lang": "nb",
 		"contentURL": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ExperimentalNorwegianList.txt",
 		"supportURL": "https://github.com/DandelionSprout/adfilt/issues"

--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -364,7 +364,7 @@
 		"group": "regions",
 		"lang": "el",
 		"supportURL": "https://github.com/kargig/greek-adblockplus-filter"
-	}
+	},
 	"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ExperimentalNorwegianList.txt": {
 		"off": true,
 		"title": "NOR: Dandelion Sprouts norske filtre for ryddigere nettsider",

--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -365,14 +365,6 @@
 		"lang": "el",
 		"supportURL": "https://github.com/kargig/greek-adblockplus-filter"
 	},
-	"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ExperimentalNorwegianList.txt": {
-		"off": true,
-		"title": "NOR: Dandelion Sprouts norske filtre for ryddigere nettsider",
-		"group": "regions",
-		"lang": "nb",
-		"supportURL": "https://github.com/DandelionSprout/adfilt/issues"
-	},
-	},
 	"https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt": {
 		"off": true,
 		"title": "SVN: Slovenian List",

--- a/assets/ublock/filter-lists.json
+++ b/assets/ublock/filter-lists.json
@@ -364,6 +364,14 @@
 		"group": "regions",
 		"lang": "el",
 		"supportURL": "https://github.com/kargig/greek-adblockplus-filter"
+	}
+	"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/ExperimentalNorwegianList.txt": {
+		"off": true,
+		"title": "NOR: Dandelion Sprouts norske filtre for ryddigere nettsider",
+		"group": "regions",
+		"lang": "nb",
+		"supportURL": "https://github.com/DandelionSprout/adfilt/issues"
+	},
 	},
 	"https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt": {
 		"off": true,


### PR DESCRIPTION
It deserves mention that I have pretty much no idea what the criteria for regional filter lists are, but I've just as well crafted such a list and am submitting it to you guys.

"Dandelion Sprouts norske filtre for ryddigere nettsider" translates as "Dandelion Sprout's Norwegian filters for tidier websites", and focuses primarily on local newssites, removing unique ads, empty boxes, and a small handful of social containers and exceptionally bothersome newsletter signups. It's also designed with the intent of being used in tandem with international adblock lists.

How often does a list have to be updated in order to stay on the filter-list selection, by the way? I don't intend to update it super-often, since there's not all that many important local websites to keep track of anyway. But I would of course try to update it often enough that the list would still be counted as relevant.