### PR TITLE
improve DOM inspector

### DIFF
--- a/platform/chromium/vapi-usercss.js
+++ b/platform/chromium/vapi-usercss.js
@@ -451,7 +451,7 @@ vAPI.DOMFilterer.prototype = {
         this.hiddenNodesetToProcess.add(node);
     },
 
-    toggle: function(state) {
+    toggle: function(state, callback) {
         vAPI.userStylesheet.toggle(state);
         var disabled = vAPI.userStylesheet.disabled,
             nodes = document.querySelectorAll('[' + this.hideNodeAttr + ']');
@@ -464,6 +464,9 @@ vAPI.DOMFilterer.prototype = {
         }
         if ( disabled === false && this.hideNodeExpando !== undefined ) {
             this.hideNodeBatchProcessTimer.start();
+        }
+        if ( typeof callback === 'function' ) {
+            callback();
         }
     },
 

--- a/platform/webext/vapi-usercss.js
+++ b/platform/webext/vapi-usercss.js
@@ -31,13 +31,13 @@ if ( typeof vAPI === 'object' ) { // >>>>>>>> start of HUGE-IF-BLOCK
 vAPI.userStylesheet = {
     added: new Set(),
     removed: new Set(),
-    apply: function() {
+    apply: function(callback) {
         if ( this.added.size === 0 && this.removed.size === 0 ) { return; }
         vAPI.messaging.send('vapi', {
             what: 'userCSS',
             add: Array.from(this.added),
             remove: Array.from(this.removed)
-        });
+        }, callback);
         this.added.clear();
         this.removed.clear();
     },
@@ -184,7 +184,7 @@ vAPI.DOMFilterer.prototype = {
         node.removeAttribute(this.hideNodeAttr);
     },
 
-    toggle: function(state) {
+    toggle: function(state, callback) {
         if ( state === undefined ) { state = this.disabled; }
         if ( state !== this.disabled ) { return; }
         this.disabled = !state;
@@ -197,7 +197,7 @@ vAPI.DOMFilterer.prototype = {
                 userStylesheet.add(rule);
             }
         }
-        userStylesheet.apply();
+        userStylesheet.apply(callback);
     },
 
     getAllSelectors_: function(all) {

--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -538,9 +538,8 @@ var cosmeticFilterMapper = (function() {
         for ( entry of (details.procedural || []) ) {
             nodes = entry.exec();
             for ( node of nodes ) {
-                if ( filterMap.has(node) === false ) {
-                    filterMap.set(node, entry.raw);
-                }
+                // Upgrade declarative selector to procedural one
+                filterMap.set(node, entry.raw);
             }
         }
     };

--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -363,6 +363,7 @@ var domLayout = (function() {
 
     var journalFromMutations = function() {
         var nodelist, node, domNode, nid;
+        mutationTimer = undefined;
 
         // This is used to temporarily hold all added nodes, before resolving
         // their node id and relative position.

--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -800,8 +800,7 @@ var start = function() {
             document.removeEventListener(ev.type, onReady);
         }
         vAPI.messaging.sendTo(loggerConnectionId, domLayout.get());
-        vAPI.domFilterer.toggle(false);
-        highlightElements();
+        vAPI.domFilterer.toggle(false, highlightElements);
     };
     if ( document.readyState === 'loading' ) {
         document.addEventListener('DOMContentLoaded', onReady);
@@ -950,9 +949,6 @@ var bootstrap = function(ev) {
     pickerDoc.body.appendChild(svgRoot);
 
     window.addEventListener('scroll', onScrolled, true);
-
-    cosmeticFilterMapper.reset();
-    highlightElements();
 
     vAPI.messaging.connectTo('domInspector', 'loggerUI', messagingHandler);
 };


### PR DESCRIPTION
- Fix race between userCSS injection and element highlight resulting in none or not all elements highlighted.
- Fix page being scanned twice resulting in unneeded slowdown.


Hi there,

I've found that the page is scanned twice. First in `bootstrap()` and later in `onReady()` both resulted in `cosmeticFilterMapper.reset();` causing massive slowdowns. Initial open of the dom inspector can take a long time ~3s or so, so it is quite important to not do the work twice by accident.

Also I've fixed visual annoyance where elements are highlighted after first scroll because of race condition between dom filtering disable and highlight code. 

Update:

* mutationTimer was not cleared resulting in any mutation update after first one to be ignored
* And procedural filters were shown with random id instead of actual filter

Thanks.
Kacper