### PR TITLE
Change URL for CZ/SK filters and add "sk" lang

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -329,8 +329,8 @@
 		"group": "regions",
 		"off": true,
 		"title": "CZE, SVK: EasyList Czech and Slovak",
-		"lang": "cs",
-		"contentURL": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt",
+		"lang": "cs sk",
+		"contentURL": "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters_ublock.txt",
 		"supportURL": "https://github.com/tomasko126/easylistczechandslovak"
 	},
 	"DEU-0": {


### PR DESCRIPTION
We've introduced a new set of filters for uBlock because some uBlock specific rules are breaking ABP and we will remove them from the `filters.txt` file.