### PR TITLE
Add 'Import and replace' buttons to 'My filters' and 'Whitelist' tabs 

### DIFF
--- a/src/1p-filters.html
+++ b/src/1p-filters.html
@@ -22,6 +22,7 @@
 <p><textarea class="userFilters" id="userFilters" dir="auto" spellcheck="false"></textarea></p>
 <p>
     <button id="importUserFiltersFromFile" class="custom" data-i18n="1pImport"></button>&ensp;
+    <button id="importUserFiltersFromFileReplace" class="custom" data-i18n="1pImportReplace"></button>&ensp;
     <button id="exportUserFiltersToFile" class="custom" data-i18n="1pExport"></button>
     <input id="importFilePicker" type="file" accept="text/plain" class="hiddenFileInput">
 </p>

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -407,6 +407,10 @@
     "message": "استيراد",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "استيراد واستبدال",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "تصدير",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "استيراد",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "استيراد واستبدال",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "تصدير",

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -407,6 +407,10 @@
     "message": "Внасяне от файл...",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Импортиране и замяна",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Изнасяне във файл",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Внасяне от файл...",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Импортиране и замяна",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Изнасяне във файл",

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -407,6 +407,10 @@
     "message": "আমদানি ও পরিশেষে যোগ করুন",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "আমদানি এবং প্রতিস্থাপন",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "রপ্তানি করুন",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "আমদানি ও পরিশেষে যোগ করুন",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "আমদানি এবং প্রতিস্থাপন",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "রপ্তানি করুন",

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -404,8 +404,12 @@
     "description": "English: One filter per line. A filter can be a plain hostname, or an Adblock Plus-compatible filter. Lines prefixed with &lsquo;!&rsquo; will be ignored."
   },
   "1pImport": {
-    "message": "Importar i annexar",
+    "message": "Importa i annexar",
     "description": "English: Import and append"
+  },
+  "1pImportReplace": {
+    "message": "Importa i reemplaça",
+    "description": "English: Import and replace"
   },
   "1pExport": {
     "message": "Exportar",
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Imporar i annexar",
+    "message": "Importa i annexar",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importa i reemplaça",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportar",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -407,6 +407,10 @@
     "message": "Importovat a připojit",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importovat a výměna",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportovat",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importovat a připojit",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importovat a výměna",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportovat",

--- a/src/_locales/cv/messages.json
+++ b/src/_locales/cv/messages.json
@@ -407,6 +407,10 @@
     "message": "Import and append",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Import and replace",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Export",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Import and append",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Import and replace",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Export",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -407,6 +407,10 @@
     "message": "Importer og tilføj",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importer og udskift",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportér",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importer og tilføj",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importer og udskift",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportér",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -407,6 +407,10 @@
     "message": "Importieren und anfügen",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importieren und ersetzen",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportieren",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importieren und anfügen",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importieren und ersetzen",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportieren",

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -407,6 +407,10 @@
     "message": "Εισαγωγή και προσάρτηση",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Εισαγωγή και αντικατάσταση",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Εξαγωγή",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Εισαγωγή και προσάρτηση",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Εισαγωγή και αντικατάσταση",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Εξαγωγή",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -407,6 +407,10 @@
     "message":"Import and append",
     "description":"English: Import and append"
   },
+  "1pImportReplace":{
+    "message":"Import and replace",
+    "description":"English: Import and replace"
+  },
   "1pExport":{
     "message":"Export",
     "description":"English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport":{
     "message":"Import and append",
     "description":"English: Import and append"
+  },
+  "whitelistImportReplace":{
+    "message":"Import and replace",
+    "description":"English: Import and replace"
   },
   "whitelistExport":{
     "message":"Export",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -407,6 +407,10 @@
     "message": "Importi kaj postaldoni",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importi kaj anstataŭigi",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksporti",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importi kaj postaldoni",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importi kaj anstataŭigi",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksporti",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -407,6 +407,10 @@
     "message": "Importar y anexar",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importar y reemplazar",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportar",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importar y anexar",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importar y reemplazar",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportar",

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -407,6 +407,10 @@
     "message": "Impordi ja lisa",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Impordi ja asendada",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Ekspordi",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Impordi ja lisa",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Impordi ja asendada",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Ekspordi",

--- a/src/_locales/eu/messages.json
+++ b/src/_locales/eu/messages.json
@@ -407,6 +407,10 @@
     "message": "Inportatu eta gehitu",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Inportatu eta ordezkatu",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Esportatu",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Inportatu eta gehitu",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Inportatu eta ordezkatu",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Esportatu",

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -407,6 +407,10 @@
     "message": "وارد کردن و الحاق",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "واردات و جایگزینی",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "خروجي گرفتن",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "وارد کردن و الحاق",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "واردات و جایگزینی",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "خروجي گرفتن",

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -407,6 +407,10 @@
     "message": "Tuo ja liitä loppuun",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Tuo ja korvaa",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Vie",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Tuo ja lisää",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Tuo ja korvaa",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Vie",

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -407,6 +407,10 @@
     "message": "I-Import at idugtong",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "I-Import at palitan",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "I-Export",
     "description": "English: Export"
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Import and append",
+    "message": "I-Import at idugtong",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "I-Import at palitan",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Export",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -404,8 +404,12 @@
     "description": "English: One filter per line. A filter can be a plain hostname, or an Adblock Plus-compatible filter. Lines prefixed with &lsquo;!&rsquo; will be ignored."
   },
   "1pImport": {
-    "message": "Importer",
+    "message": "Importer et ajouter",
     "description": "English: Import and append"
+  },
+  "1pImportReplace": {
+    "message": "Importer et remplacer",
+    "description": "English: Import and replace"
   },
   "1pExport": {
     "message": "Exporter",
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Importer",
+    "message": "Importer et ajouter",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importer et remplacer",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exporter",

--- a/src/_locales/fy/messages.json
+++ b/src/_locales/fy/messages.json
@@ -407,6 +407,10 @@
     "message": "Ymportearje en tafoegje",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Ymportearje en ferfange",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportearje",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Ymportearje en tafoegje",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Ymportearje en ferfange",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportearje",

--- a/src/_locales/gl/messages.json
+++ b/src/_locales/gl/messages.json
@@ -407,6 +407,10 @@
     "message": "Importar e anexar",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importar e substituír",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportar",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importar e anexar",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importar e substituír",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportar",

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -407,6 +407,10 @@
     "message": "ייבא וצרף",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "ייבוא והחלפה",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "ייצוא",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "ייבא וצרף",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "ייבוא והחלפה",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "ייצוא",

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -404,8 +404,12 @@
     "description": "English: One filter per line. A filter can be a plain hostname, or an Adblock Plus-compatible filter. Lines prefixed with &lsquo;!&rsquo; will be ignored."
   },
   "1pImport": {
-    "message": "Import and append",
+    "message": "आयात करें और संलग्न करें",
     "description": "English: Import and append"
+  },
+  "1pImportReplace": {
+    "message": "आयात और प्रतिस्थापित करें",
+    "description": "English: Import and replace"
   },
   "1pExport": {
     "message": "निर्यात करें",
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Import and append",
+    "message": "आयात करें और संलग्न करें",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "आयात और प्रतिस्थापित करें",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "निर्यात करें",

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -407,6 +407,10 @@
     "message": "Uvesti i dodati",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Uvoz i zamjena",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Izvoz",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Uvesti i dodati",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Uvoz i zamjena",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Izvoz",

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -407,6 +407,10 @@
     "message": "Importál és hozzáad",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importál és csere",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportál",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importál és hozzáad",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importál és csere",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportál",

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -407,6 +407,10 @@
     "message": "Impor dan tambahkan",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Impor dan ganti",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Ekspor",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Impor dan tambahkan",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Impor dan ganti",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Ekspor",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -407,6 +407,10 @@
     "message": "Importa e aggiungi",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importa e sostituisci",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Esporta",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importa e aggiungi",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importa e sostituisci",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Esporta",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -407,6 +407,10 @@
     "message": "インポートと追加",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "インポートと置換",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "エクスポート",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "インポートと追加",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "インポートと置換",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "エクスポート",

--- a/src/_locales/ka/messages.json
+++ b/src/_locales/ka/messages.json
@@ -404,8 +404,12 @@
     "description": "English: One filter per line. A filter can be a plain hostname, or an Adblock Plus-compatible filter. Lines prefixed with &lsquo;!&rsquo; will be ignored."
   },
   "1pImport": {
-    "message": "Import and append",
+    "message": "იმპორტი და დამატება",
     "description": "English: Import and append"
+  },
+  "1pImportReplace": {
+    "message": "იმპორტი და შეცვალეთ",
+    "description": "English: Import and replace"
   },
   "1pExport": {
     "message": "გამოტანა",
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Import and append",
+    "message": "იმპორტი და დამატება",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "იმპორტი და შეცვალეთ",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Export",

--- a/src/_locales/kn/messages.json
+++ b/src/_locales/kn/messages.json
@@ -407,6 +407,10 @@
     "message": "ಆಮದಿಸಿ ಸೇರ್ಪಡಿಸು",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "ಆಮದು ಮಾಡಿ ಮತ್ತು ಬದಲಿಸಿ",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "ರಫ್ತು",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Import and append",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "ಆಮದು ಮಾಡಿ ಮತ್ತು ಬದಲಿಸಿ",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Export",

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -407,6 +407,10 @@
     "message": "가져오기 및 추가하기",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "가져 오기 및 바꾸기",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "내보내기",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "가져오기 및 추가하기",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "가져 오기 및 바꾸기",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "내보내기",

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -407,6 +407,10 @@
     "message": "Importuoti ir papildyti",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importuoti ir pakeisti",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportuoti",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importuoti ir papildyti",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importuoti ir pakeisti",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportuoti",

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -407,6 +407,10 @@
     "message": "Importēt un pievienot",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importēt un nomainiet",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportēt",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importēt un pievienot",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importēt un nomainiet",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportēt",

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -407,6 +407,10 @@
     "message": "ഇമ്പോര്‍ട്ടും കൂട്ടിചേര്‍ക്കലും ചെയ്യുക",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "ഇറക്കുമതി ചെയ്ത് പകരം വയ്ക്കുക",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "എക്സ്പോര്‍ട്ട്‌",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "ഇമ്പോര്‍ട്ടും കൂട്ടിചേര്‍ക്കലും ചെയ്യുക",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "ഇറക്കുമതി ചെയ്ത് പകരം വയ്ക്കുക",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "എക്സ്പോര്‍ട്ട്‌",

--- a/src/_locales/mr/messages.json
+++ b/src/_locales/mr/messages.json
@@ -407,6 +407,10 @@
     "message": "आयात आणि समावेश करा",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "आयात आणि पुनर्स्थित करा",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "निर्यात करा",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "आयात आणि समावेश करा",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "आयात आणि पुनर्स्थित करा",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "निर्यात करा",

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -404,8 +404,12 @@
     "description": "English: One filter per line. A filter can be a plain hostname, or an Adblock Plus-compatible filter. Lines prefixed with &lsquo;!&rsquo; will be ignored."
   },
   "1pImport": {
-    "message": "Import and append",
+    "message": "Import dan tambah",
     "description": "English: Import and append"
+  },
+  "1pImportReplace": {
+    "message": "Import dan gantikan",
+    "description": "English: Import and replace"
   },
   "1pExport": {
     "message": "Export",
@@ -472,8 +476,12 @@
     "description": "English: An overview of the content of the dashboard's Whitelist pane."
   },
   "whitelistImport": {
-    "message": "Import and append",
+    "message": "Import dan tambah",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Import dan gantikan",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Export",

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -407,6 +407,10 @@
     "message": "Importer og legg til",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Import og erstatt",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksporter",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importer og legg til",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Import og erstatt",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksporter",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -407,6 +407,10 @@
     "message": "Importeren en toevoegen",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importeren en vervangen",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exporteren",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importeren en toevoegen",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importeren en vervangen",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exporteren",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -407,6 +407,10 @@
     "message": "Importuj i dołącz",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importuj i zamień",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportuj",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importuj i dołącz",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importuj i zamień",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportuj",

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -407,6 +407,10 @@
     "message": "Importar e adicionar",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importar e substituir",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportar",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importar e adicionar",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importar e substituir",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportar",

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -407,6 +407,10 @@
     "message": "Importar e anexar",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importar e substituir",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportar",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importar e anexar",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": ,"Importar e substituir"
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportar",

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -407,6 +407,10 @@
     "message": "Importă și adaugă",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importă și înlocuiți",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportă",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importă și adaugă",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importă și înlocuiți",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportă",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -407,6 +407,10 @@
     "message": "Импортировать и добавить",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Импорт и замена",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Экспортировать",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Импортировать и добавить",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Импорт и замена",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Экспортировать",

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -407,6 +407,10 @@
     "message": "Importovať a pripojiť",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importovať a výmena",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportovať",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importovať a pripojiť",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importovať a výmena",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportovať",

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -407,6 +407,10 @@
     "message": "Uvozi in dodaj",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Uvozi in zamenjaj",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Izvozi",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Uvozi in dodaj",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Uvozi in zamenjaj",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Izvozi",

--- a/src/_locales/sq/messages.json
+++ b/src/_locales/sq/messages.json
@@ -407,6 +407,10 @@
     "message": "Importoj dhe shtoj",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importoj dhe zëvendësoni",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Eksportoj",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importoj dhe shtoj",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importoj dhe zëvendësoni",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Eksportoj",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -407,6 +407,10 @@
     "message": "Увези и додај",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Увезите и замените",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Извези",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Увези и додај",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Увезите и замените",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Извези",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -407,6 +407,10 @@
     "message": "Importera och lägg till",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Importera och ersätt",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Exportera",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Importera och lägg till",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Importera och ersätt",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Exportera",

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -407,6 +407,10 @@
     "message": "இறக்குமதி செய் மற்றும் இணை",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "இறக்குமதி செய்து மாற்றவும்",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "ஏற்று",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Import and append",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "இறக்குமதி செய்து மாற்றவும்",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "ஏற்று",

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -407,6 +407,10 @@
     "message": "దిగుమతిచేసి పోడిగించుము",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "దిగుమతి చేసి, భర్తీ చేయండి",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "ఎగుమతి చేయు",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "దిగుమతిచేసి పోడిగించుము",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "దిగుమతి చేసి, భర్తీ చేయండి",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "ఎగుమతి",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -407,6 +407,10 @@
     "message": "İçe aktar ve sonuna ekle",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "İçe aktarma ve değiştirme",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Dışa aktar",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "İçe aktar ve sonuna ekle",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "İçe aktarma ve değiştirme",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Dışa aktar",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -407,6 +407,10 @@
     "message": "Імпортувати та додати",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Імпортуйте і замініть",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Експортувати",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Імпортувати та додати",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Імпортуйте і замініть",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Експортувати",

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -407,6 +407,10 @@
     "message": "Nhập và thêm vào",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "Nhập và thay thế",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "Xuất",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "Nhập và thêm vào",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "Nhập và thay thế",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "Xuất",

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -407,6 +407,10 @@
     "message": "导入并添加",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "导入和替换",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "导出",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "导入并添加",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "导入和替换",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "导出",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -407,6 +407,10 @@
     "message": "匯入並加入",
     "description": "English: Import and append"
   },
+  "1pImportReplace": {
+    "message": "導入和替換",
+    "description": "English: Import and replace"
+  },
   "1pExport": {
     "message": "匯出",
     "description": "English: Export"
@@ -474,6 +478,10 @@
   "whitelistImport": {
     "message": "匯入並加入",
     "description": "English: Import and append"
+  },
+  "whitelistImportReplace": {
+    "message": "導入和替換",
+    "description": "English: Import and replace"
   },
   "whitelistExport": {
     "message": "匯出",

--- a/src/js/1p-filters.js
+++ b/src/js/1p-filters.js
@@ -29,8 +29,9 @@
 
 /******************************************************************************/
 
-var messaging = vAPI.messaging;
-var cachedUserFilters = '';
+var messaging = vAPI.messaging,
+    cachedUserFilters = '',
+    importAction = '';
 
 /******************************************************************************/
 
@@ -101,7 +102,11 @@ var handleImportFilePicker = function() {
     var fileReaderOnLoadHandler = function() {
         var sanitized = abpImporter(this.result);
         var textarea = uDom('#userFilters');
-        textarea.val(textarea.val().trim() + '\n' + sanitized);
+        if ( importAction === 'append' ) {
+            textarea.val(textarea.val().trim() + '\n' + sanitized);
+        } else if ( importAction === 'replace' ) {
+            textarea.val(sanitized);
+        }
         userFiltersChanged();
     };
     var file = this.files[0];
@@ -195,7 +200,14 @@ self.cloud.onPull = setCloudData;
 /******************************************************************************/
 
 // Handle user interaction
-uDom('#importUserFiltersFromFile').on('click', startImportFilePicker);
+uDom('#importUserFiltersFromFile').on('click', function() {
+    importAction = 'append';
+    startImportFilePicker();
+});
+uDom('#importUserFiltersFromFileReplace').on('click', function() {
+    importAction = 'replace';
+    startImportFilePicker();
+});
 uDom('#importFilePicker').on('change', handleImportFilePicker);
 uDom('#exportUserFiltersToFile').on('click', exportUserFiltersToFile);
 uDom('#userFilters').on('input', userFiltersChanged);

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -30,7 +30,8 @@
 /******************************************************************************/
 
 var messaging = vAPI.messaging,
-    cachedWhitelist = '';
+    cachedWhitelist = '',
+    importAction = '';
 
 /******************************************************************************/
 
@@ -101,7 +102,11 @@ var renderWhitelist = function() {
 var handleImportFilePicker = function() {
     var fileReaderOnLoadHandler = function() {
         var textarea = getTextareaNode();
-        textarea.value = [textarea.value.trim(), this.result.trim()].join('\n').trim();
+        if ( importAction === 'append' ) {
+            textarea.value = [textarea.value.trim(), this.result.trim()].join('\n').trim();
+        } else if ( importAction === 'replace' ) {
+            textarea.value = [this.result.trim()].join('\n').trim();
+        }
         whitelistChanged();
     };
     var file = this.files[0];
@@ -180,7 +185,14 @@ self.cloud.onPull = setCloudData;
 
 /******************************************************************************/
 
-uDom('#importWhitelistFromFile').on('click', startImportFilePicker);
+uDom('#importWhitelistFromFile').on('click', function() {
+    importAction = 'append';
+    startImportFilePicker();
+});
+uDom('#importWhitelistFromFileReplace').on('click', function() {
+    importAction = 'replace';
+    startImportFilePicker();
+});
 uDom('#importFilePicker').on('change', handleImportFilePicker);
 uDom('#exportWhitelistToFile').on('click', exportWhitelistToFile);
 uDom('#whitelist textarea').on('input', whitelistChanged);

--- a/src/whitelist.html
+++ b/src/whitelist.html
@@ -24,6 +24,7 @@
     </section>
 <p>
     <button id="importWhitelistFromFile" class="custom" data-i18n="whitelistImport"></button>&ensp;
+    <button id="importWhitelistFromFileReplace" class="custom" data-i18n="whitelistImportReplace"></button>&ensp;
     <button id="exportWhitelistToFile" class="custom" data-i18n="whitelistExport"></button>
     <input id="importFilePicker" type="file" accept="text/plain" class="hiddenFileInput">
 


### PR DESCRIPTION
In relation to: https://github.com/gorhill/uBlock/issues/3358

Tested on macOS 10.13.2 on Firefox 57.0.1, Firefox 58.0b12 and Chrome 63.0.3239.108.

Localisations provided on a best effort basis.