### PR TITLE
xpinstall.signatures.required support

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -22,7 +22,7 @@ Remember that you have to update manually also. For some users, updating manuall
 
 ### Firefox webext
 
-Compatible with Firefox 52 and beyond. This works only if you set `xpinstall.signatures.required` to `false` in `about:config`.
+Compatible with Firefox 52 and beyond[*][*]. This works only if you set `xpinstall.signatures.required` to `false` in `about:config`.
 
 - Download `ublock0.webext.xpi` ([latest release desirable](https://github.com/gorhill/uBlock/releases)).
     - Right-click and choose _"Save As..."_.
@@ -32,6 +32,8 @@ On Linux, the settings are saved in a JSON file located at `~/.mozilla/firefox/[
 
 When you uninstall the extension, Firefox deletes that file, so all your settings are lost when you uninstall.
 
+\* - [Add-on signing in Firefox - What are my options if I want to use an unsigned add-on?][*]
+
 ### Firefox legacy
 
 Compatible with Firefox 24 to Firefox 56.
@@ -39,13 +41,17 @@ Compatible with Firefox 24 to Firefox 56.
 - Download `ublock0.firefox.xpi` ([latest release desirable](https://github.com/gorhill/uBlock/releases)). 
 - Drag and drop the previously downloaded `ublock0.firefox.xpi` into Firefox
 
-With Firefox 43 and beyond, you may need to toggle the setting `xpinstall.signatures.required` to `false` in `about:config`.
+With Firefox 43 and beyond[*][*], you may need to toggle the setting `xpinstall.signatures.required` to `false` in `about:config`.
 
 Your uBlock Origin settings are kept intact even after you uninstall the addon.
 
 On Linux, the settings are saved in a SQlite file located at `~/.mozilla/firefox/[profile name]/extension-data/ublock0.sqlite`.
 
 On Windows, the settings are saved in a SQlite file located at `%APPDATA%\Mozilla\Firefox\Profiles\[profile name]\extension-data\ublock0.sqlite`.
+
+\* - [Add-on signing in Firefox - What are my options if I want to use an unsigned add-on?][*]
+    
+[*]: https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox "Add-on signing in Firefox - What are my options if I want to use an unsigned add-on?"
 
 ### Build instructions (for developers)
 


### PR DESCRIPTION
Links when `xpinstall.signatures.required` does not work - propose change build Firefox to Developer / Nightly / unbranded.

---

May possible unlock in stable version if find working code `config.js` + `config-prefs.js` for Firefox 57+ - https://www.ghacks.net/2016/08/14/override-firefox-add-on-signing-requirement/
  
  
  