### PR TITLE
Fix toggling of firewall when disabling advanced mode

### DIFF
--- a/src/js/ublock.js
+++ b/src/js/ublock.js
@@ -337,9 +337,7 @@ var reInvalidHostname = /[^a-z0-9.\-\[\]:]/,
     // Post-change
     switch ( name ) {
     case 'advancedUserEnabled':
-        if ( value === true ) {
-            us.dynamicFilteringEnabled = true;
-        }
+        us.dynamicFilteringEnabled = value;
         break;
     case 'autoUpdate':
         this.scheduleAssetUpdater(value ? 7 * 60 * 1000 : 0);


### PR DESCRIPTION
Fixes an issue affecting all platforms mentioned in https://github.com/nikrolls/uBlock-Edge/pull/103 where toggling `advancedUser` from the popup results in the firewall pane remaining open.

Issue repro steps:
- From the popup, open the dashboard and enable advancedUser
- Open the popup and confirm firewall pane is automatically expanded
- From the opened popup open the dashboard and disable advancedUser
- Open the popup and notice firewall pane is still automatically expanded

Proposed fix:
When `advancedUserEnabled` is fired, also set `us.dynamicFilteringEnabled` to reflect the change.