### PR TITLE
Specify a transform value at 0% keyframe

### DIFF
--- a/src/css/3p-filters.css
+++ b/src/css/3p-filters.css
@@ -1,4 +1,5 @@
 @keyframes spin {
+    0% { transform: rotate(0deg); -webkit-transform: rotate(0deg); }
     100% { transform: rotate(360deg); -webkit-transform: rotate(360deg); }
     }
 ul {


### PR DESCRIPTION
In Firefox, transform animations which don't specify 0% or 100% keyframe value
are not properly optimized if the animations are scrolled-out [1]. Such
animations unfortunately consume much CPU rather than visible ones. An easy
way to avoid this is to specify the missing keyframe value.

This patch will fix #3577.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1430884