### PR TITLE
Accept `# Title:` and `# Expires:`; optimize RegExp

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -733,7 +733,7 @@
     // https://github.com/gorhill/uBlock/issues/313
     // Always try to fetch the name if this is an external filter list.
     if ( listEntry.title === '' || listEntry.group === 'custom' ) {
-        matches = head.match(/(?:^|\n)!\s*Title:([^\n]+)/i);
+        matches = head.match(/(?:^|\n)(?:!|#)\s*Title:([^\n]+)/i);
         if ( matches !== null ) {
             // https://bugs.chromium.org/p/v8/issues/detail?id=2869
             // JSON.stringify/JSON.parse is to work around String.slice()
@@ -743,7 +743,7 @@
         }
     }
     // Extract update frequency information
-    matches = head.match(/(?:^|\n)![\t ]*Expires:[\t ]*([\d]+)[\t ]*days?/i);
+    matches = head.match(/(?:^|\n)(?:!|#)[\t ]*Expires:[\t ]*(\d+)[\t ]*day/i);
     if ( matches !== null ) {
         v = Math.max(parseInt(matches[1], 10), 1);
         if ( v !== listEntry.updateAfter ) {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -733,7 +733,7 @@
     // https://github.com/gorhill/uBlock/issues/313
     // Always try to fetch the name if this is an external filter list.
     if ( listEntry.title === '' || listEntry.group === 'custom' ) {
-        matches = head.match(/(?:^|\n)(?:!|#)\s*Title:([^\n]+)/i);
+        matches = head.match(/(?:^|\n)(?:!|# )\s*Title:([^\n]+)/i);
         if ( matches !== null ) {
             // https://bugs.chromium.org/p/v8/issues/detail?id=2869
             // JSON.stringify/JSON.parse is to work around String.slice()
@@ -743,7 +743,7 @@
         }
     }
     // Extract update frequency information
-    matches = head.match(/(?:^|\n)(?:!|#)[\t ]*Expires:[\t ]*(\d+)[\t ]*day/i);
+    matches = head.match(/(?:^|\n)(?:!|# )[\t ]*Expires:[\t ]*(\d+)[\t ]*day/i);
     if ( matches !== null ) {
         v = Math.max(parseInt(matches[1], 10), 1);
         if ( v !== listEntry.updateAfter ) {


### PR DESCRIPTION
### Accept `# Title:` and `# Expires:`

This allows hosts file authors to set a title and an expiry time for their hosts files. 
Although `!Title:...` is accepted, to prevent confusion with static network filter, `#Title:...` is not accepted, `#` must be followed by a space for the header to be valid. Same thing for the `Expires` header. 

### Optimize `Expires` header matching pattern

`[\d]+` is unnecessary as there is only one element in the bracket, it is equivalent to `\d+`. Matching the trailing `s?` is basically a no-op, since `/days?/` matches `dayy` just fine. The final RegExp looks like this: 

![image](https://user-images.githubusercontent.com/7283682/38394450-ca12baaa-38eb-11e8-9a93-95f412adda03.png)
![image](https://user-images.githubusercontent.com/7283682/38394457-d2ab902e-38eb-11e8-98a1-485eb28958f9.png)
