### PR TITLE
Accept `ubo://` as alternative to `abp://`

### DIFF
--- a/src/js/scriptlets/subscriber.js
+++ b/src/js/scriptlets/subscriber.js
@@ -66,7 +66,7 @@ var onMaybeAbpLinkClicked = function(ev) {
     if ( href === '' ) {
         return;
     }
-    var matches = /^abp:\/*subscribe\/*\?location=([^&]+).*title=([^&]+)/.exec(href);
+    var matches = /^(?:abp|ubo):\/*subscribe\/*\?location=([^&]+).*title=([^&]+)/.exec(href);
     if ( matches === null ) {
         matches = /^https?:\/\/.*?[&?]location=([^&]+).*?&title=([^&]+)/.exec(href);
         if ( matches === null ) { return; }
@@ -112,7 +112,7 @@ var onMaybeAbpLinkClicked = function(ev) {
 setTimeout(function() {
     if (
         document.querySelector('link[rel="canonical"][href="https://filterlists.com/"]') !== null ||
-        document.querySelector('a[href^="abp:"],a[href^="https://subscribe.adblockplus.org/?"]') !== null
+        document.querySelector('a[href^="abp:"],a[href^="ubo:"],a[href^="https://subscribe.adblockplus.org/?"]') !== null
     ) {
         document.addEventListener('click', onMaybeAbpLinkClicked);
     }


### PR DESCRIPTION
This helps to prevent AdBlock and ABP from reacting to subscription links of uBO-only filters. 

When an "invalid" filter is loaded into AdBlock or ABP, unless the user manually remove it, it seems that AdBlock and ABP will keep trying to download/update those filters, creating unnecessary traffic to filter lists servers. 

(I did a quick test by manually initiating a filter update, I'd guess automatic updates will behave the same)
