### PR TITLE
Fix wiki link to Permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Being lean and efficient doesn't mean blocking less<br>
 
 ## Installation
 
-Feel free to read [about the extension's required permissions](https://github.com/gorhill/uBlock/wiki/About-the-required-permissions).
+Feel free to read [about the extension's required permissions](https://github.com/gorhill/uBlock/wiki/Permissions).
 
 #### Chromium
 


### PR DESCRIPTION
The Wiki page about uBlock's permissions was renamed and the link in the README did no longer work