### PR TITLE
try-catch scriptlets to prevent crash

### DIFF
--- a/src/js/scriptlet-filtering.js
+++ b/src/js/scriptlet-filtering.js
@@ -65,6 +65,10 @@
                 content = patchScriptlet(content, args);
                 if ( !content ) { return; }
             }
+            content =
+                'try {\n' +
+                    content + '\n' +
+                '} catch ( e ) { }';
             scriptletCache.add(raw, content);
         }
         toInject.set(raw, content);


### PR DESCRIPTION
Currently, a bad scriptlet that crashes can prevent following scriptlets to run, and the injected `<script>` element will not be cleaned up. 

The proposed changes has negligible effect on performance as the scriptlet only run once per page. 

In terms of scriptlet debugging, a userscript manager should be much easier to use than loading a resource file with advanced settings; also recent changes on redirect engine caching makes loading a new version of custom resource file rather difficult. 

Example bad scriptlet rules: 
```
example.com##script:inject(abort-on-property-write.js, test)
example.com##script:inject(abort-on-property-read.js, test)
```

@gorhill 
