### PR TITLE
Fix RegExp escape

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -797,7 +797,7 @@
         staticExtFilteringEngine = this.staticExtFilteringEngine,
         reIsWhitespaceChar = /\s/,
         reMaybeLocalIp = /^[\d:f]/,
-        reIsLocalhostRedirect = /\s+(?:0.0.0.0|broadcasthost|ip6-all(?:nodes|routers)|local|localhost|localhost\.localdomain)\b/,
+        reIsLocalhostRedirect = /\s+(?:0\.0\.0\.0|broadcasthost|ip6-all(?:nodes|routers)|local|localhost|localhost\.localdomain)\b/,
         reLocalIp = /^(?:0\.0\.0\.0|127\.0\.0\.1|::1|fe80::1%lo0)/,
         line, c, pos,
         lineIter = new this.LineIterator(this.processDirectives(rawText));


### PR DESCRIPTION
`.` in RegExp means match any character that is not new line, which doesn't seem right in this context. 

Problem introduced in https://github.com/gorhill/uBlock/commit/26c2320e46e84ddff8e076e4c4162b58c82a05a2

@gorhill 
