### PR TITLE
Clear return value of vapi.js content script

### DIFF
--- a/platform/chromium/vapi.js
+++ b/platform/chromium/vapi.js
@@ -53,4 +53,8 @@ if (
         : { uBO: true };
 }
 
+// Set the value of the last expression to undefined to avoid serializing the
+// vAPI object when the content script is run using chrome.tabs.executeScript.
+void 0;
+
 /******************************************************************************/


### PR DESCRIPTION
Upon start-up, uBlock runs all content scripts in manifest.json using `chrome.tabs.executeScript`. When this API is used, the value of the last expression is automatically cloned and transferred to the callback of `chrome.tabs.executeScript`. This is convenient if needed, and a performance burden otherwise (the latter is the case for uBlock).

There are three content scripts that need to be checked:

- vapi.js
  The last expression is often the vAPI object, and it is relatively expensive to clone this object. This commit sets the value of the last expression to `void 0` to solve this inefficiency.
  https://github.com/gorhill/uBlock/blob/820ec69916c16056c047b5b6cbc5f1954c677f1b/platform/chromium/vapi.js#L51-L56

- vapi-client.js
  No action needed yet; The last expression is `vAPI.shutdown.add(...)`, which has a void return value.
  https://github.com/gorhill/uBlock/blob/820ec69916c16056c047b5b6cbc5f1954c677f1b/platform/chromium/vapi-client.js#L49-L53
  https://github.com/gorhill/uBlock/blob/820ec69916c16056c047b5b6cbc5f1954c677f1b/platform/chromium/vapi-client.js#L436-L447

- contentscript.js
  No action needed yet; The last expression is an immediately-invoked function expression without return value.
  https://github.com/gorhill/uBlock/blob/820ec69916c16056c047b5b6cbc5f1954c677f1b/src/js/contentscript.js#L1267-L1417