### PR TITLE
New mirror for MDL

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -172,7 +172,11 @@
 		"group": "malware",
 		"title": "Malware Domain List",
 		"contentURL": [
+			"https://cdn.rawgit.com/NanoMeow/MDLMirror/master/hosts.txt",
+			"https://raw.githubusercontent.com/NanoMeow/MDLMirror/master/hosts.txt",
 			"https://www.malwaredomainlist.com/hostslist/hosts.txt",
+			"https://cdn.rawgit.com/NanoMeow/MDLMirror/master/filter.txt",
+			"https://raw.githubusercontent.com/NanoMeow/MDLMirror/master/filter.txt",
 			"assets/thirdparties/www.malwaredomainlist.com/hostslist/hosts.txt"
 		]
 	},


### PR DESCRIPTION
As you know, the MDL server is really unstable, so I made a (flavored) mirror of it, a bot will (try to) update the mirror every 24 hours. Should it fail to download the filter, it will try again in 1 hour, until it works. 

![image](https://user-images.githubusercontent.com/7283682/40736201-97f46548-63fa-11e8-9942-3a77079c8443.png)

No entry is added or removed (except local domains which would cause trouble if I left them in there). It has proper headers and is pre-parsed (`127.0.0.1` and other stuff removed, transpiled to raw hosts name format and ABP filter format). 

Content URLs:
```
https://cdn.rawgit.com/NanoMeow/MDLMirror/master/hosts.txt
https://cdn.rawgit.com/NanoMeow/MDLMirror/master/filter.txt
```

The mirror repo: https://github.com/NanoMeow/MDLMirror

@gorhill 
