### PR TITLE
Prevent race condition when saving `LocalSettings`

### DIFF
--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -796,16 +796,21 @@ var restoreUserData = function(request) {
 // quite attached to numbers
 
 var resetUserData = function() {
-    let count = 3;
-    let countdown = ( ) => {
-        count -= 1;
-        if ( count === 0 ) {
-            vAPI.app.restart();
+    const onSaveLocalSettingsDone = ( ) => {
+        vAPI.app.restart();
+    };
+
+    let cleared = 0;
+    const onStorageClearDone = ( ) => {
+        cleared += 1;
+        if ( cleared === 2 ) {
+            µb.saveLocalSettings(onSaveLocalSettingsDone);
         }
     };
-    vAPI.cacheStorage.clear(countdown); // 1
-    vAPI.storage.clear(countdown);      // 2
-    µb.saveLocalSettings(countdown);    // 3
+
+    vAPI.cacheStorage.clear(onStorageClearDone); // 1
+    vAPI.storage.clear(onStorageClearDone);      // 2
+
     vAPI.localStorage.removeItem('immediateHiddenSettings');
 };
 


### PR DESCRIPTION
Clearing extension storage is *not* synchronous, unlike `localStorage`. Maybe it's synchronous for Chromium under the hood, but it's not in the doc so don't rely on it. 
You should wait for the storage clearing to finish before saving `LocalSettings`. Even if the current code works, leaving it as-is can cause intermittent faults at a debugging-insanity-inducing frequency in the future. 

Also, `const` and `let` are introduced together, I don't see why you are defining functions with `let`. `const` just means the identifier cannot be reassigned, the value it contains can still be modified (if the value is mutable, for example, if it's an array then you can still push into it). If you still want `let`, you can push to https://github.com/jspenguin2017/uBlock/blob/patch-1/src/js/messaging.js to change it. 

This should fix https://github.com/uBlockOrigin/uBlock-issues/issues/144 for good. 

@gorhill 
