### PR TITLE
Two (small) optimizations

### DIFF
--- a/src/js/assets.js
+++ b/src/js/assets.js
@@ -368,8 +368,7 @@ var getAssetSourceRegistry = function(callback) {
     var registryReady = function() {
         var callers = assetSourceRegistryStatus;
         assetSourceRegistryStatus = 'ready';
-        var fn;
-        while ( (fn = callers.shift()) ) {
+        for ( var fn of callers ) {
             fn(assetSourceRegistry);
         }
     };

--- a/src/js/redirect-engine.js
+++ b/src/js/redirect-engine.js
@@ -341,8 +341,8 @@ RedirectEngine.prototype.compileRuleFromStaticFilter = function(line) {
         return;
     }
 
-    // Need one single type -- not negated.
-    if ( type === undefined || type.startsWith('~') ) {
+    // Need one single type -- validated before.
+    if ( type === undefined ) {
         return;
     }
 


### PR DESCRIPTION
`assets.js`: Avoid `while...shift` loop, it runs in `O(n^2)`. Use `for...of` loop instead (`while...pop` loop is also OK, but I see no reason to use it over a simple `for` loop). The `callers` variable is local so this is safe. 

---

`redirect-engine.js`: `type` is a local variable, and it is only assigned on line 334: 
```
 type = this.supportedTypes[option];
```
Since it is already validated, there is no reason to validate it again. 

---

@gorhill 