### PR TITLE
Add subscriber scriptlet to frames

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -45,7 +45,7 @@
         "/js/scriptlets/subscriber.js"
       ],
       "run_at": "document_idle",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "default_locale": "en",

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -53,7 +53,7 @@
         "/js/scriptlets/subscriber.js"
       ],
       "run_at": "document_idle",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "default_locale": "en",

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -37,7 +37,7 @@
       "run_at": "document_start"
     },
     {
-      "all_frames": false,
+      "all_frames": true,
       "js": [
         "js/scriptlets/subscriber.js"
       ],

--- a/platform/webext/manifest.json
+++ b/platform/webext/manifest.json
@@ -53,7 +53,7 @@
         "/js/scriptlets/subscriber.js"
       ],
       "run_at": "document_idle",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "default_locale": "en",


### PR DESCRIPTION
If a `abp:subscribe` or `ubo:subscribe` link is inside of an iframe then uBlock Origin doesn't register a click handler to listen for the click. The click handler is only added if there is a subscribe achor on the page and registered to run at `document_idle`, so it shouldn't cause performance issues.