### PR TITLE
New Polish anti-adblock list

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -541,11 +541,20 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "POL: polskie filtry do Adblocka i uBlocka",
+		"title": "POL: Oficjalne Polskie Filtry do AdBlocka, uBlocka Origin i AdGuarda",
 		"lang": "pl",
 		"contentURL": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
 		"supportURL": "https://github.com/MajkiIT/polish-ads-filter/issues",
 		"instructionURL": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard"
+	},
+	"POL-1": {
+		"content": "filters",
+		"group": "regions",
+		"off": true,
+		"title": "POL: Oficjalne polskie filtry przeciwko alertom o Adblocku",
+		"lang": "pl",
+		"contentURL": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
+		"supportURL": "https://github.com/olegwukr/polish-privacy-filters/issues"
 	},
 	"ROU-1": {
 		"content": "filters",

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -547,7 +547,7 @@
 		"supportURL": "https://github.com/MajkiIT/polish-ads-filter/issues",
 		"instructionURL": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard"
 	},
-	"POL-1": {
+	"POL-2": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,


### PR DESCRIPTION
Anti-adblock filters have been moved from main list to different repo.

[Official announcement](https://www.certyficate.it/polskie-filtry-anti-adblock-brak-wsparcia-w-polskich-filtrach-szanowni-nasi-drodzy-od-07-12-2018-nastapia-zmiany-w-oficjalnych-polskich-filtrach/)

See also https://github.com/NanoAdblocker/NanoCore/issues/232

Thanks @KonoromiHimaries

***

And updated titles. Not too long?