### PR TITLE
Add has-inner-text filter.

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -412,6 +412,23 @@ vAPI.DOMFilterer = (function() {
         return output;
     };
 
+    const PSelectorHasInnerTextTask = function(task) {
+        let arg0 = task[1], arg1;
+        if ( Array.isArray(task[1]) ) {
+            arg1 = arg0[1]; arg0 = arg0[0];
+        }
+        this.needle = new RegExp(arg0, arg1);
+    };
+    PSelectorHasInnerTextTask.prototype.exec = function(input) {
+        const output = [];
+        for ( const node of input ) {
+            if ( this.needle.test(node.innerText) ) {
+                output.push(node);
+            }
+        }
+        return output;
+    };
+
     const PSelectorIfTask = function(task) {
         this.pselector = new PSelector(task[1]);
     };
@@ -553,6 +570,7 @@ vAPI.DOMFilterer = (function() {
             PSelector.prototype.operatorToTaskMap = new Map([
                 [ ':has', PSelectorIfTask ],
                 [ ':has-text', PSelectorHasTextTask ],
+                [ ':has-inner-text', PSelectorHasInnerTextTask ],
                 [ ':if', PSelectorIfTask ],
                 [ ':if-not', PSelectorIfNotTask ],
                 [ ':matches-css', PSelectorMatchesCSSTask ],

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -161,6 +161,7 @@
                 'contains',
                 'has',
                 'has-text',
+                'has-inner-text',
                 'if',
                 'if-not',
                 'matches-css',
@@ -272,6 +273,7 @@
         const compileArgument = new Map([
             [ ':has', compileConditionalSelector ],
             [ ':has-text', compileText ],
+            [ ':has-inner-text', compileText ],
             [ ':if', compileConditionalSelector ],
             [ ':if-not', compileConditionalSelector ],
             [ ':matches-css', compileCSSDeclaration ],
@@ -304,6 +306,7 @@
                     raw.push(':has', '(', decompile(task[1]), ')');
                     break;
                 case ':has-text':
+                case ':has-inner-text':
                     if ( Array.isArray(task[1]) ) {
                         value = '/' + task[1][0] + '/' + task[1][1];
                     } else {


### PR DESCRIPTION
This can be used to break some facebook obfsucation.
Filter example:
`facebook.com,facebookcorewwwi.onion##div[id^="hyperfeed_story_id_"]:has(div[id^="feedsubtitle_"]):has([role="button"]:has-inner-text(Sponsored))`