### PR TITLE
Update download location for firefox-legacy releases

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -46,7 +46,7 @@ When you uninstall the extension, Firefox deletes that file, so all your setting
 
 Compatible with Firefox 24-56, [Pale Moon](https://www.palemoon.org/) and [SeaMonkey](http://www.seamonkey-project.org/).
 
-- Download `ublock0.firefox-legacy.xpi` ([latest release desirable](https://github.com/gorhill/uBlock/releases)).
+- Download `ublock0.firefox-legacy.xpi` ([latest release desirable](https://github.com/gorhill/uBlock-for-firefox-legacy/releases)).
     - Right-click and select "Save Link As..."
 - Drag and drop the previously downloaded `ublock0.firefox-legacy.xpi` into Firefox
 


### PR DESCRIPTION
Update download location for firefox-legacy releases according to https://github.com/gorhill/uBlock/pull/3766#issuecomment-575710895.