### PR TITLE
Add `env_legacy` to the pre-processor supported tokens

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -957,6 +957,7 @@ self.addEventListener('hiddenSettingsChanged', ( ) => {
     [ 'env_chromium', 'chromium' ],
     [ 'env_edge', 'edge' ],
     [ 'env_firefox', 'firefox' ],
+    [ 'env_legacy', 'legacy' ],
     [ 'env_mobile', 'mobile' ],
     [ 'env_safari', 'safari' ],
     [ 'cap_html_filtering', 'html_filtering' ],


### PR DESCRIPTION
This will allow specifically target uBlock Origin for Firefox legacy-based browsers in shared filter lists,
see https://github.com/gorhill/uBlock-for-firefox-legacy/pull/1.