### PR TITLE
Change whitelist->allowlist in en/en-GB

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -40,7 +40,7 @@
     "description": "appears as tab name in dashboard"
   },
   "whitelistPageName":{
-    "message":"Whitelist",
+    "message":"Allowlist",
     "description":"appears as tab name in dashboard"
   },
   "shortcutsPageName":{
@@ -552,8 +552,8 @@
     "description": "English: dynamic rule syntax and full documentation."
   },
   "whitelistPrompt":{
-    "message":"The whitelist directives dictate on which web pages uBlock Origin should be disabled. One entry per line. Invalid directives will be silently ignored and commented out.",
-    "description":"English: An overview of the content of the dashboard's Whitelist pane."
+    "message":"The allowlist directives dictate on which web pages uBlock Origin should be disabled. One entry per line. Invalid directives will be silently ignored and commented out.",
+    "description":"English: An overview of the content of the dashboard's Allowlist pane."
   },
   "whitelistImport":{
     "message":"Import and append",

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -40,7 +40,7 @@
     "description": "appears as tab name in dashboard"
   },
   "whitelistPageName": {
-    "message": "Whitelist",
+    "message": "Allowlist",
     "description": "appears as tab name in dashboard"
   },
   "shortcutsPageName": {
@@ -552,8 +552,8 @@
     "description": "English: dynamic rule syntax and full documentation."
   },
   "whitelistPrompt": {
-    "message": "The whitelist directives dictate on which web pages uBlock Origin should be disabled. One entry per line. Invalid directives will be silently ignored and commented out.",
-    "description": "English: An overview of the content of the dashboard's Whitelist pane."
+    "message": "The allowlist directives dictate on which web pages uBlock Origin should be disabled. One entry per line. Invalid directives will be silently ignored and commented out.",
+    "description": "English: An overview of the content of the dashboard's Allowlist pane."
   },
   "whitelistImport": {
     "message": "Import and append",


### PR DESCRIPTION
Replace the world "whitelist" with "allowlist".

Lately many organizations have been working to remove the terms blacklist and whitelist from their systems. Associating black and white with positive/negative or allow/block has a real impact on people. The IETF has a short but well written discussion of this issue: https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.2

This minor change only affects the en and en-GB translations, internally references to a whitelist remain. This PR is intended to make the smallest possible change without risk of breaking things, while still having a meaningful and visible impact.