### PR TITLE
uBlock for firefox legacy is auto-updating

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -58,8 +58,6 @@ On Linux, the settings are saved in a SQlite file located at `~/.mozilla/firefox
 
 On Windows, the settings are saved in a SQlite file located at `%APPDATA%\Mozilla\Firefox\Profiles\[profile name]\extension-data\ublock0.sqlite`.
 
-If you want to automatically receive updates for this version, you can also install [uBlock Origin Updater](https://github.com/JustOff/ublock0-updater).
-
 ### Build instructions (for developers)
 
 - Clone [uBlock](https://github.com/gorhill/uBlock) and [uAssets](https://github.com/uBlockOrigin/uAssets) repositories in the same parent directory


### PR DESCRIPTION
from GitHub after [1.16.4.17](https://github.com/gorhill/uBlock-for-firefox-legacy/releases/tag/firefox-legacy-1.16.4.17).

Discussed on Reddit: https://www.reddit.com/r/uBlockOrigin/comments/ikbuog/does_ublock_for_firefox_legacy_update_itself/