### PR TITLE
Pass -e flag to bash

### DIFF
--- a/tools/copy-common-files.sh
+++ b/tools/copy-common-files.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/import-crowdin.sh
+++ b/tools/import-crowdin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-assets.sh
+++ b/tools/make-assets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-browser.sh
+++ b/tools/make-browser.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-chromium.sh
+++ b/tools/make-chromium.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-clean.sh
+++ b/tools/make-clean.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 
 echo "*** uBlock: Cleaning."
-rm -R dist/build
+rm -Rf dist/build
 echo "*** uBlock: Cleaned."

--- a/tools/make-firefox.sh
+++ b/tools/make-firefox.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-opera.sh
+++ b/tools/make-opera.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/make-thunderbird.sh
+++ b/tools/make-thunderbird.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 

--- a/tools/update-submodules.sh
+++ b/tools/update-submodules.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 #
 # This script assumes a linux environment
 


### PR DESCRIPTION
Since the scripts in the `tools` directory are being called via `make`, which in turn is invoked from external scripts, it would be ideal to pass the `-e` flag to `bash`.