### PR TITLE
Use lower case for Node.js package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install-nodejs: dist/build/uBlock0.nodejs.tgz
 
 # Uninstall the Node.js package.
 uninstall-nodejs:
-	npm uninstall uBO-snfe --no-save
+	npm uninstall ubo-snfe --no-save
 
 # Update submodules.
 update-submodules:

--- a/platform/nodejs/package.json
+++ b/platform/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "uBO-snfe",
+  "name": "ubo-snfe",
   "version": "0.1.0",
   "description": "To create a working instance of uBlock's static network filtering engine",
   "type": "module",


### PR DESCRIPTION
Packages published on npm [must have a name that is all lower case](https://blog.npmjs.org/post/168978377570/new-package-moniker-rules.html).

This also prevents issues on systems like macOS that have case-insensitive filesystems.

Discussion here: https://github.com/gorhill/uBlock/pull/3789#issuecomment-890412888