### PR TITLE
Serialize PSL in Node.js install script

### DIFF
--- a/platform/nodejs/install.js
+++ b/platform/nodejs/install.js
@@ -1,0 +1,33 @@
+/*******************************************************************************
+
+    uBlock Origin - a browser extension to block requests.
+    Copyright (C) 2014-present Raymond Hill
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see {http://www.gnu.org/licenses/}.
+
+    Home: https://github.com/gorhill/uBlock
+*/
+
+'use strict';
+
+/******************************************************************************/
+
+import fs from 'fs';
+
+import { pslInit } from './main.js';
+
+/******************************************************************************/
+
+fs.writeFileSync('./build/publicsuffixlist.json',
+                 JSON.stringify(pslInit().toSelfie()));

--- a/platform/nodejs/main.js
+++ b/platform/nodejs/main.js
@@ -101,6 +101,20 @@ async function enableWASM() {
 function pslInit(raw) {
     if ( typeof raw !== 'string' || raw.trim() === '' ) {
         const require = createRequire(import.meta.url); // jshint ignore:line
+
+        let serialized = null;
+
+        // Use serialized version if available
+        try {
+            serialized = require('./build/publicsuffixlist.json');
+        } catch (error) {
+        }
+
+        if (serialized !== null) {
+            globals.publicSuffixList.fromSelfie(serialized);
+            return globals.publicSuffixList;
+        }
+
         raw = require('./data/effective_tld_names.json');
         if ( typeof raw !== 'string' || raw.trim() === '' ) {
             console.error('Unable to populate public suffix list');

--- a/platform/nodejs/package.json
+++ b/platform/nodejs/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
+    "install": "node install.js",
     "test": "node test.js"
   },
   "repository": {

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -47,6 +47,9 @@ node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easylist.txt', 'utf8'))" \
 node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easyprivacy.txt', 'utf8'))" \
     > $DES/data/easyprivacy.json
 
+rm -rf $DES/build
+mkdir -p $DES/build
+
 cp platform/nodejs/*.js   $DES/
 cp platform/nodejs/*.json $DES/
 cp LICENSE.txt            $DES/


### PR DESCRIPTION
`install.js` is the install script and is executed automatically when the Node.js package is installed. It builds `publicsuffixlist.json`, which is the serialized version of the PSL. `pslInit()` now tries to use `publicsuffixlist.json` and otherwise falls back to the raw PSL.