### PR TITLE
Generate bundle.min.cjs in Node.js install script

### DIFF
--- a/platform/nodejs/main.js
+++ b/platform/nodejs/main.js
@@ -146,6 +146,14 @@ function reset() {
     snfe.reset();
 }
 
+// rollup.js needs module.exports to be set back to the local exports object.
+// This is because some of the code (e.g. publicsuffixlist.js) sets
+// module.exports. Once all included files are written like ES modules, using
+// export statements, this should no longer be necessary.
+if (typeof module !== 'undefined' && typeof exports !== 'undefined') {
+  module.exports = exports;
+}
+
 export {
     FilteringContext,
     enableWASM,

--- a/platform/nodejs/package.json
+++ b/platform/nodejs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
-    "install": "node install.js",
+    "install": "node install.js && rollup main.js --file bundle.min.cjs --format cjs --context global --plugin terser",
     "test": "node test.js"
   },
   "repository": {
@@ -22,5 +22,9 @@
   "bugs": {
     "url": "https://github.com/gorhill/uBlock/issues"
   },
-  "homepage": "https://github.com/gorhill/uBlock#readme"
+  "homepage": "https://github.com/gorhill/uBlock#readme",
+  "dependencies": {
+    "rollup": "^2.55.1",
+    "rollup-plugin-terser": "^7.0.2"
+  }
 }


### PR DESCRIPTION
Following up from the discussion here: https://github.com/cliqz-oss/adblocker/pull/2091#issuecomment-890532011

The Node.js install script now generates a `bundle.min.cjs` file.

