### PR TITLE
Run ESLint during Node.js package generation

### DIFF
--- a/platform/nodejs/eslintrc.json
+++ b/platform/nodejs/eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "env": {
+        "es2021": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": [ "warn", 4 ],
+        "getter-return": "off",
+        "no-control-regex": "off",
+        "no-empty": [ "error", { "allowEmptyCatch": true } ],
+        "no-useless-escape": "off"
+    }
+}

--- a/platform/nodejs/test.js
+++ b/platform/nodejs/test.js
@@ -19,6 +19,7 @@
     Home: https://github.com/gorhill/uBlock
 */
 
+/* eslint-disable-next-line no-redeclare */
 /* globals process */
 
 'use strict';

--- a/src/js/biditrie.js
+++ b/src/js/biditrie.js
@@ -19,7 +19,7 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* globals WebAssembly */
+/* globals WebAssembly vAPI */
 
 'use strict';
 
@@ -223,7 +223,7 @@ const BidiTrieContainer = class {
             }
             if ( al === aR ) { return 0; }
         }
-        return 0;
+        return 0; // eslint-disable-line no-unreachable
     }
 
     matchesLeft(icell, ar, r) {
@@ -267,7 +267,7 @@ const BidiTrieContainer = class {
                 if ( icell === 0 ) { return 0; }
             }
         }
-        return 0;
+        return 0; // eslint-disable-line no-unreachable
     }
 
     matchesExtra(l, r, ix) {
@@ -513,6 +513,7 @@ const BidiTrieContainer = class {
                     }
                     // TODO: we should never reach here because there will
                     // always be a boundary cell.
+                    // eslint-disable-next-line no-debugger
                     debugger; // jshint ignore:line
                     // boundary cell + needle remainder
                     inext = this.addCell(0, 0, 0);

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -19,6 +19,8 @@
     Home: https://github.com/gorhill/uBlock
 */
 
+/* globals self */
+
 'use strict';
 
 /******************************************************************************/

--- a/src/js/hntrie.js
+++ b/src/js/hntrie.js
@@ -19,7 +19,7 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* globals WebAssembly */
+/* globals WebAssembly vAPI */
 
 'use strict';
 

--- a/src/js/static-filtering-parser.js
+++ b/src/js/static-filtering-parser.js
@@ -19,6 +19,8 @@
     Home: https://github.com/gorhill/uBlock
 */
 
+/* globals document */
+
 'use strict';
 
 /******************************************************************************/

--- a/src/js/static-net-filtering.js
+++ b/src/js/static-net-filtering.js
@@ -19,6 +19,8 @@
     Home: https://github.com/gorhill/uBlock
 */
 
+/* globals vAPI */
+
 'use strict';
 
 /******************************************************************************/

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -54,6 +54,8 @@ cp platform/nodejs/*.js   $DES/
 cp platform/nodejs/*.json $DES/
 cp LICENSE.txt            $DES/
 
+eslint -c platform/nodejs/eslintrc.json $DES/js $DES/*.js
+
 if [ "$1" = all ]; then
     echo "*** uBlock0.nodejs: Creating plain package..."
     pushd $(dirname $DES/) > /dev/null


### PR DESCRIPTION
This patch updates the build script for the Node.js package to run [ESLint](https://eslint.org/) before creating the ZIP file. A most basic ESLint configuration file is included. Any initial errors have been ignored explicitly for now.

In order to minimize disruption, only the Node.js package is being linted for now.

This should help to identify issues with the porting to ES modules.

More in inline comments.