### PR TITLE
Create build folder in npm install script

### DIFF
--- a/platform/nodejs/install.js
+++ b/platform/nodejs/install.js
@@ -29,5 +29,6 @@ import { pslInit } from './index.js';
 
 /******************************************************************************/
 
+fs.mkdirSync('./build', { recursive: true });
 fs.writeFileSync('./build/publicsuffixlist.json',
                  JSON.stringify(pslInit().toSelfie()));

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -6,6 +6,8 @@ set -e
 
 DES=dist/build/uBlock0.nodejs
 
+rm -rf $DES
+
 mkdir -p $DES/js
 cp src/js/base64-custom.js           $DES/js
 cp src/js/biditrie.js                $DES/js
@@ -46,9 +48,6 @@ node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easylist.txt', 'utf8'))" \
     > $DES/data/easylist.json
 node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easyprivacy.txt', 'utf8'))" \
     > $DES/data/easyprivacy.json
-
-rm -rf $DES/build
-mkdir -p $DES/build
 
 cp platform/nodejs/*.js   $DES/
 cp platform/nodejs/*.json $DES/


### PR DESCRIPTION
Either tar or npm is ignoring the empty build folder on some systems. This causes package installation to fail. The npm install script now creates the folder if it does not exist.