### PR TITLE
Move linting out of tools/make-nodejs.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean install chromium firefox nodejs install-nodejs-link install-nodejs uninstall-nodejs
+.PHONY: all clean lint install chromium firefox nodejs install-nodejs-link install-nodejs uninstall-nodejs
 
 sources := $(wildcard src/* src/*/* src/*/*/* src/*/*/*/*)
 platform := $(wildcard platform/* platform/*/*)
@@ -43,6 +43,11 @@ install-nodejs: dist/build/uBlock0.nodejs.tgz
 # Uninstall the Node.js package.
 uninstall-nodejs:
 	npm uninstall '@gorhill/ubo-core' --no-save
+
+lint: nodejs
+	eslint -c platform/nodejs/eslintrc.json \
+		dist/build/uBlock0.nodejs/js \
+		dist/build/uBlock0.nodejs/*.js
 
 # Update submodules.
 update-submodules:

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -56,11 +56,6 @@ cp platform/nodejs/*.js   $DES/
 cp platform/nodejs/*.json $DES/
 cp LICENSE.txt            $DES/
 
-# Ignore eslint when building with GitHub Actions
-if [ -z "$GITHUB_REF" ]; then
-    eslint -c platform/nodejs/eslintrc.json $DES/js $DES/*.js
-fi
-
 if [ "$1" = all ]; then
     echo "*** uBlock0.nodejs: Creating plain package..."
     pushd $(dirname $DES/) > /dev/null


### PR DESCRIPTION
This patch moves the linting out of the `tools/make-nodejs.sh` script, as it continues to cause problems (see https://github.com/cliqz-oss/adblocker/pull/2109#issuecomment-892816406).

Now the developer must run `make lint` explicitly.