### PR TITLE
Fix pslInit() for install script

### DIFF
--- a/platform/nodejs/index.js
+++ b/platform/nodejs/index.js
@@ -101,6 +101,7 @@ function pslInit(raw) {
         console.error('Unable to populate public suffix list');
         return;
     }
+    globals.publicSuffixList.parse(raw, globals.punycode.toASCII);
     return globals.publicSuffixList;
 }
 


### PR DESCRIPTION
Following up from here: https://github.com/cliqz-oss/adblocker/pull/2138#issuecomment-895604055

We need to parse the public suffix list.