### PR TITLE
Remove install-nodejs and related make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean lint install chromium firefox nodejs install-nodejs-link install-nodejs uninstall-nodejs
+.PHONY: all clean lint chromium firefox nodejs
 
 sources := $(wildcard src/* src/*/* src/*/*/* src/*/*/*/*)
 platform := $(wildcard platform/* platform/*/*)
@@ -26,23 +26,6 @@ dist/build/uBlock0.nodejs: tools/make-nodejs.sh $(sources) $(platform) $(assets)
 
 # Build the Node.js package.
 nodejs: dist/build/uBlock0.nodejs
-
-# Install the Node.js package as a link in the node_modules directory. This is
-# convenient for development, but it breaks when the dist/build directory is
-# cleaned up.
-install-nodejs-link: dist/build/uBlock0.nodejs
-	npm install dist/build/uBlock0.nodejs --no-save
-
-dist/build/uBlock0.nodejs.tgz: dist/build/uBlock0.nodejs
-	cd dist/build && tar czf uBlock0.nodejs.tgz uBlock0.nodejs
-
-# Install the Node.js package.
-install-nodejs: dist/build/uBlock0.nodejs.tgz
-	npm install dist/build/uBlock0.nodejs.tgz --no-save
-
-# Uninstall the Node.js package.
-uninstall-nodejs:
-	npm uninstall '@gorhill/ubo-core' --no-save
 
 lint: nodejs
 	eslint -c platform/nodejs/eslintrc.json \


### PR DESCRIPTION
Now with the Cliqz benchmarks using the npm version of the Node.js package (https://github.com/cliqz-oss/adblocker/pull/2138) there's no need for the `install-nodejs`, `install-nodejs-link`, and `uninstall-nodejs` make targets.