### PR TITLE
Use npm pack

### DIFF
--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -59,6 +59,8 @@ cp LICENSE.txt               $DES/
 
 cd $DES
 npm run build
+tarballname=$(npm pack 2> /dev/null)
+mv $tarballname ../uBlock0.nodejs.tgz
 cd -
 
 if [ "$1" = all ]; then


### PR DESCRIPTION
We can use the [`npm pack`](https://docs.npmjs.com/cli/v7/commands/npm-pack) command to build an installable tarball that automatically excludes files in `.gitignore` and `.npmignore` as well as directories like `node_modules`.