### PR TITLE
Add .npmrc to stop generating package lock file

### DIFF
--- a/platform/nodejs/.npmrc
+++ b/platform/nodejs/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -52,6 +52,7 @@ node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easylist.txt', 'utf8'))" \
 node -pe "JSON.stringify(fs.readFileSync('$THIRDPARTY/easyprivacy.txt', 'utf8'))" \
     > $DES/data/easyprivacy.json
 
+cp platform/nodejs/.npmrc    $DES/
 cp platform/nodejs/.*.json   $DES/
 cp platform/nodejs/*.js      $DES/
 cp platform/nodejs/*.json    $DES/


### PR DESCRIPTION
When we run `npm install` from within the package directory, it generates a [`package-lock.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json) file. This is not needed unless there are actual dependencies. ubo-core only has development dependencies, no other dependencies.

This patch adds a `.npmrc` file that instructs `npm` not to generate a `package-lock.json` file.