### PR TITLE
Spawn mocha from test.js

### DIFF
--- a/platform/nodejs/package.json
+++ b/platform/nodejs/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "node build.js",
     "lint": "eslint js/ *.js",
-    "test": "mocha tests"
+    "test": "node test.js --mocha"
   },
   "repository": {
     "type": "git",

--- a/platform/nodejs/test.js
+++ b/platform/nodejs/test.js
@@ -27,7 +27,9 @@
 /******************************************************************************/
 
 import { strict as assert } from 'assert';
+import { spawn } from "child_process";
 import { createRequire } from 'module';
+import { promisify } from 'util';
 
 import {
     enableWASM,
@@ -131,6 +133,10 @@ async function doHNTrie() {
     console.log("anotherTrie.matches('foo.invalid')", anotherTrie.matches('foo.invalid'));
 }
 
+async function spawnMocha() {
+    await promisify(spawn)('mocha', [ 'tests' ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
+}
+
 async function main() {
     try {
         const result = await enableWASM();
@@ -144,7 +150,9 @@ async function main() {
     await doSNFE();
     await doHNTrie();
 
-    process.exit();
+    if ( process.argv[2] === '--mocha' ) {
+        await spawnMocha();
+    }
 }
 
 main();

--- a/platform/nodejs/tests/snfe.js
+++ b/platform/nodejs/tests/snfe.js
@@ -24,86 +24,16 @@
 /******************************************************************************/
 
 import { strict as assert } from 'assert';
-import { createRequire } from 'module';
 
 import {
-    enableWASM,
     StaticNetFilteringEngine,
 } from '../index.js';
 
 let engine = null;
 
 describe('SNFE', () => {
-    function fetch(listName) {
-        return new Promise(resolve => {
-            const require = createRequire(import.meta.url); // jshint ignore:line
-            resolve(require(`../data/${listName}.json`));
-        });
-    }
-
-    function testSNFE(engine) {
-        let result = 0;
-
-        // Tests
-        // Not blocked
-        result = engine.matchRequest({
-          originURL: 'https://www.bloomberg.com/',
-          url: 'https://www.bloomberg.com/tophat/assets/v2.6.1/that.css',
-          type: 'stylesheet'
-        });
-        if ( result !== 0 ) {
-            engine.toLogData();
-        }
-
-        // Blocked
-        result = engine.matchRequest({
-          originURL: 'https://www.bloomberg.com/',
-          url: 'https://securepubads.g.doubleclick.net/tag/js/gpt.js',
-          type: 'script'
-        });
-        if ( result !== 0 ) {
-            engine.toLogData();
-        }
-
-        // Unblocked
-        result = engine.matchRequest({
-          originURL: 'https://www.bloomberg.com/',
-          url: 'https://sourcepointcmp.bloomberg.com/ccpa.js',
-          type: 'script'
-        });
-        if ( result !== 0 ) {
-            engine.toLogData();
-        }
-    }
-
     before(async () => {
         engine = await StaticNetFilteringEngine.create();
-    });
-
-    describe('Basic', async () => {
-        beforeEach(async () => {
-            await engine.useLists([
-                fetch('easylist').then(raw => ({ name: 'easylist', raw })),
-                fetch('easyprivacy').then(raw => ({ name: 'easyprivacy', raw })),
-            ]);
-        });
-
-        it ('should work', async () => {
-            testSNFE(engine);
-
-            const serialized = await engine.serialize();
-            await engine.useLists([]);
-
-            assert.notDeepEqual(await engine.serialize(), serialized);
-
-            testSNFE(engine);
-
-            await engine.deserialize(serialized);
-
-            assert.deepEqual(await engine.serialize(), serialized);
-
-            testSNFE(engine);
-        });
     });
 
     describe('Filter loading', () => {


### PR DESCRIPTION
We can spawn `mocha` as a child process from `test.js`. This allows the basic tests to remain in `test.js` and additional Mocha tests to go into the `./tests` directory. It also allows multiple runs of `mocha` with options like `--enable-wasm` in the future, as well as programmatic test generation with a request data set.