### PR TITLE
Fix $TMPDIR check in make-nodejs.sh

### DIFF
--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -79,7 +79,7 @@ fi
 cd -
 
 # Restore saved npm dependencies
-if [ -n "$TMPDIR" ]; then
+if [ -d "$TMPDIR/node_modules" ]; then
     mv "$TMPDIR/node_modules" "$DES/node_modules"
     rmdir "$TMPDIR"
 fi


### PR DESCRIPTION
`make nodejs` fails on a clean repo or after `make clean`.

Here we're using `-d` instead of `-n` and checking specifically for the `node_modules` directory.