### PR TITLE
Use local tmp directory

### DIFF
--- a/tools/make-nodejs.sh
+++ b/tools/make-nodejs.sh
@@ -6,10 +6,12 @@ set -e
 
 DES=dist/build/uBlock0.nodejs
 
+TMPDIR=tmp
+mkdir -p $TMPDIR
+
 # Save existing npm dependencies if present so that we do not have to fetch
 # them all again
 if [ -d "$DES/node_modules" ]; then
-    TMPDIR=`mktemp -d`
     mv "$DES/node_modules" "$TMPDIR/node_modules"
 fi
 
@@ -81,7 +83,6 @@ cd -
 # Restore saved npm dependencies
 if [ -d "$TMPDIR/node_modules" ]; then
     mv "$TMPDIR/node_modules" "$DES/node_modules"
-    rmdir "$TMPDIR"
 fi
 
 echo "*** uBlock0.nodejs: Package done."


### PR DESCRIPTION
The current solution (https://github.com/gorhill/uBlock/pull/3820) still gives errors on macOS.

```
make clean
make test
touch platform/nodejs/test.js
make test
```

I get an error saying that the directory is not empty.

Here I'm using the local `tmp` directory, which can remain and is already ignored in `.gitignore`.