### PR TITLE
Test in new world

### DIFF
--- a/platform/nodejs/package-lock.json
+++ b/platform/nodejs/package-lock.json
@@ -462,6 +462,11 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
+    "esm-world": {
+      "version": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
+      "from": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
+      "dev": true
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",

--- a/platform/nodejs/package.json
+++ b/platform/nodejs/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
+    "esm-world": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
     "mocha": "^9.0.3"
   }
 }

--- a/platform/nodejs/test.js
+++ b/platform/nodejs/test.js
@@ -134,7 +134,7 @@ async function doHNTrie() {
 }
 
 async function spawnMocha() {
-    await promisify(spawn)('mocha', [ 'tests' ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
+    await promisify(spawn)('mocha', [ '--experimental-vm-modules', '--no-warnings', 'tests' ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
 }
 
 async function main() {

--- a/platform/nodejs/tests/snfe.js
+++ b/platform/nodejs/tests/snfe.js
@@ -24,22 +24,28 @@
 /******************************************************************************/
 
 import { strict as assert } from 'assert';
+import process from 'process';
 
-import {
-    StaticNetFilteringEngine,
-} from '../index.js';
+import { createWorld } from 'esm-world';
+
+process.on('warning', warning => {
+    // Ignore warnings about experimental features like
+    // --experimental-vm-modules
+    if ( warning.name !== 'ExperimentalWarning' ) {
+        console.warn(warning.stack);
+    }
+});
 
 let engine = null;
 
 describe('SNFE', () => {
-    before(async () => {
-        engine = await StaticNetFilteringEngine.create();
-    });
-
     describe('Filter loading', () => {
         beforeEach(async () => {
-            // This is in lieu of a constructor for a non-singleton.
-            await engine.useLists([]);
+            const globals = { URL, setTimeout, clearTimeout };
+
+            const { StaticNetFilteringEngine } = await createWorld('./index.js', { globals });
+
+            engine = await StaticNetFilteringEngine.create();
         });
 
         it('should not reject on no lists', async () => {


### PR DESCRIPTION
We need to run each test in its own world.

This is possible for ES modules using the new [`vm.Module`](https://nodejs.org/api/vm.html#vm_class_vm_module) experimental API.

Things to note:

* `package.json` and `package-lock.json` now use a specific version of the new [esm-world](https://github.com/mjethani/esm-world) package (under development)
* We pass `--experimental-vm-modules` to Node.js to enable the `vm.Module` API
* Since this API is experimental, we also pass `--no-warnings` to suppress all warnings by default
* We don't want to suppress _all_ warnings, only the ones about experimental features, and therefore we add a listener for the `warning` event and print all other warnings
* The `beforeEach()` handler now loads the package's `index.js` in its own world before each test

More explanation in the inline comments.