### PR TITLE
Use createWorld() in request data tests

### DIFF
--- a/platform/npm/package-lock.json
+++ b/platform/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorhill/ubo-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -526,8 +526,9 @@
       "dev": true
     },
     "esm-world": {
-      "version": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
-      "from": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/esm-world/-/esm-world-0.1.1.tgz",
+      "integrity": "sha512-BrUju/zoltW1L3MXWM3WZFpZddekSLnl0st7L//luZs3fbJ/o/3knWByewSic3RsMWCp3lGIh0GfA9WOEU8QxQ==",
       "dev": true
     },
     "espree": {

--- a/platform/npm/package.json
+++ b/platform/npm/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "c8": "^7.8.0",
     "eslint": "^7.32.0",
-    "esm-world": "github:mjethani/esm-world#0e5a77a5c0cb22de28616bba9ed7247dee218fb3",
+    "esm-world": "0.1.1",
     "mocha": "^9.0.3",
     "scaling-palm-tree": "github:mjethani/scaling-palm-tree#15cf1ab37e038771e1ff8005edc46d95f176739f"
   }

--- a/platform/npm/tests/_common.js
+++ b/platform/npm/tests/_common.js
@@ -19,33 +19,16 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* eslint-disable-next-line no-redeclare */
-/* globals process */
-
 'use strict';
 
 /******************************************************************************/
 
-import { spawn } from "child_process";
-import { promisify } from 'util';
+import process from 'process';
 
-/******************************************************************************/
-
-async function spawnMocha() {
-    const files = [
-        'tests/snfe.js',
-        'tests/request-data.js',
-    ];
-
-    await promisify(spawn)('mocha', [ '--experimental-vm-modules', '--no-warnings', ...files, '--reporter', 'progress' ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
-}
-
-async function main() {
-    if ( process.argv[2] === '--mocha' ) {
-        await spawnMocha();
+process.on('warning', warning => {
+    // Ignore warnings about experimental features like
+    // --experimental-vm-modules
+    if ( warning.name !== 'ExperimentalWarning' ) {
+        console.warn(warning.stack);
     }
-}
-
-main();
-
-/******************************************************************************/
+});

--- a/platform/npm/tests/snfe.js
+++ b/platform/npm/tests/snfe.js
@@ -24,17 +24,10 @@
 /******************************************************************************/
 
 import { strict as assert } from 'assert';
-import process from 'process';
 
 import { createWorld } from 'esm-world';
 
-process.on('warning', warning => {
-    // Ignore warnings about experimental features like
-    // --experimental-vm-modules
-    if ( warning.name !== 'ExperimentalWarning' ) {
-        console.warn(warning.stack);
-    }
-});
+import './_common.js';
 
 let engine = null;
 


### PR DESCRIPTION
This patch updates `request-data.js` in the `tests` directory to use `createWorld()` in order to ensure that the Wasm and non-Wasm sets of the tests run in their own worlds.

For example, the order in which the Wasm and non-Wasm sets are run is no longer significant.

There is one relevant commit in esm-world: https://github.com/mjethani/esm-world/commit/4d569baa9f0bbac9ab9507a77d8f0ae7a45aa553