### PR TITLE
Add --full-battery option for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ lint: npm
 test: npm
 	cd dist/build/uBlock0.npm && npm run test
 
+test-full-battery: npm
+	cd dist/build/uBlock0.npm && npm run test-full-battery
+
 dist/build/uBlock0.dig: tools/make-nodejs.sh $(sources) $(platform) $(assets)
 	tools/make-dig.sh
 

--- a/platform/npm/package.json
+++ b/platform/npm/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "node build.js",
     "lint": "eslint js/ *.js tests/*.js",
-    "test": "c8 --include=index.js --include=js/**/*.js node test.js --mocha"
+    "test": "c8 --include=index.js --include=js/**/*.js node test.js --mocha",
+    "test-full-battery": "c8 --include=index.js --include=js/**/*.js node test.js --mocha --full-battery"
   },
   "repository": {
     "type": "git",

--- a/platform/npm/test.js
+++ b/platform/npm/test.js
@@ -34,10 +34,17 @@ import { promisify } from 'util';
 async function spawnMocha() {
     const files = [
         'tests/snfe.js',
-        'tests/request-data.js',
     ];
 
-    await promisify(spawn)('mocha', [ '--experimental-vm-modules', '--no-warnings', ...files, '--reporter', 'progress' ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
+    const options = [];
+
+    if ( process.argv[3] === '--full-battery' ) {
+        files.push('tests/request-data.js');
+
+        options.push('--reporter', 'progress');
+    }
+
+    await promisify(spawn)('mocha', [ '--experimental-vm-modules', '--no-warnings', ...files, ...options ], { stdio: [ 'inherit', 'inherit', 'inherit' ] });
 }
 
 async function main() {


### PR DESCRIPTION
The tests take too long to run right now for every change. The tests in `platform/npm/tests/request-data.js` are great to run before a release or even after a significant change to the engine, but most of the time it should not be necessary to run them. This patch adds a `--full-battery` option to `platform/npm/test.js`, which is not passed by default. Use `make test-full-battery` to run _all_ the Mocha tests.