### PR TITLE
Add check-leaks make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test: npm
 test-full-battery: npm
 	cd dist/build/uBlock0.npm && npm run test-full-battery
 
+check-leaks: npm
+	cd dist/build/uBlock0.npm && npm run check-leaks
+
 dist/build/uBlock0.dig: tools/make-nodejs.sh $(sources) $(platform) $(assets)
 	tools/make-dig.sh
 

--- a/platform/npm/package.json
+++ b/platform/npm/package.json
@@ -8,7 +8,8 @@
     "build": "node build.js",
     "lint": "eslint js/ *.js tests/*.js",
     "test": "c8 --include=index.js --include=js/**/*.js node test.js --mocha",
-    "test-full-battery": "c8 --include=index.js --include=js/**/*.js node test.js --mocha --full-battery"
+    "test-full-battery": "c8 --include=index.js --include=js/**/*.js node test.js --mocha --full-battery",
+    "check-leaks": "mocha --check-leaks tests/leaks.js"
   },
   "repository": {
     "type": "git",

--- a/platform/npm/tests/leaks.js
+++ b/platform/npm/tests/leaks.js
@@ -19,35 +19,12 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* globals WebAssembly */
-
 'use strict';
 
 /******************************************************************************/
 
-import { strict as assert } from 'assert';
-
-import { createWorld } from 'esm-world';
-
-import './_common.js';
-
-describe('WASM', () => {
-    context('WebAssembly available', () => {
-        it('should fulfill with true', async () => {
-            const { enableWASM } = await createWorld('./index.js', { globals: { URL, WebAssembly } });
-
-            assert.equal(await enableWASM(), true);
-        });
-    });
-
-    context('WebAssembly not available', () => {
-        it('should fulfill with false', async () => {
-            // WebAssembly must be set to undefined explicitly; otherwise
-            // createWorld() ends up using the global WebAssembly object
-            // anyway.
-            const { enableWASM } = await createWorld('./index.js', { globals: { URL, WebAssembly: undefined } });
-
-            assert.equal(await enableWASM(), false);
-        });
+describe('Leaks', () => {
+    it('should not leak', async () => {
+        await import('../index.js');
     });
 });


### PR DESCRIPTION
Mocha has a [`--check-leaks` option](https://mochajs.org/#-check-leaks) for checking if there are any global variable leaks. We do have leaks here, but it would be good to keep track.

Run `make check-leaks`.

Output:

```
Error: global leak(s) detected: 'punycode', 'publicSuffixList', 'location', 'requestIdleCallback', 'cancelIdleCallback', 'Regex'
```