### PR TITLE
Make shallow copy of globals

### DIFF
--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -27,13 +27,25 @@
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 
-const globals = (( ) => {
+const realGlobals = (( ) => {
     // jshint ignore:start
     if ( typeof globalThis !== 'undefined' ) { return globalThis; }
     if ( typeof self !== 'undefined' ) { return self; }
     if ( typeof global !== 'undefined' ) { return global; }
     // jshint ignore:end
+    throw new Error('unable to locate global object');
 })();
+
+// Make a shallow copy so as not to pollute the global namespace.
+const globals = Object.assign({}, realGlobals);
+
+if ( 'WebAssembly' in realGlobals ) {
+    globals.WebAssembly = realGlobals.WebAssembly;
+}
+
+if ( 'URLSearchParams' in realGlobals ) {
+    globals.URLSearchParams = realGlobals.URLSearchParams;
+}
 
 // https://en.wikipedia.org/wiki/.invalid
 if ( globals.location === undefined ) {


### PR DESCRIPTION
At the moment the Node.js package adds `location`, `requestIdleCallback`, and `clearIdleCallback` to the global namespace. This is not ideal as it could interfere with other code in the same program (e.g. other packages checking for Node.js vs. browser based on the presence of the `location` property).

Since the `location` property is always being accessed via the `globals` object exported from `src/js/globals.js`, the `globals` object could be a shallow copy of the effective `globalThis` object.