### PR TITLE
Convert regex.js into an ES module

### DIFF
--- a/src/js/static-filtering-parser.js
+++ b/src/js/static-filtering-parser.js
@@ -25,9 +25,7 @@
 
 /******************************************************************************/
 
-import '../lib/regexanalyzer/regex.js';
-
-import globals from './globals.js';
+import Regex from '../lib/regexanalyzer/regex.js';
 
 /*******************************************************************************
 
@@ -2898,7 +2896,6 @@ Parser.regexUtils = Parser.prototype.regexUtils = (( ) => {
         return '\x01';
     };
 
-    const Regex = globals.Regex;
     if (
         Regex instanceof Object === false ||
         Regex.Analyzer instanceof Object === false

--- a/src/lib/regexanalyzer/regex.js
+++ b/src/lib/regexanalyzer/regex.js
@@ -7,23 +7,7 @@
 *   https://github.com/foo123/RegexAnalyzer
 *
 **/
-!function( root, name, factory ){
-"use strict";
-if ( ('object'===typeof module)&&module.exports ) /* CommonJS */
-    (module.$deps = module.$deps||{}) && (module.exports = module.$deps[name] = factory.call(root));
-else if ( ('undefined'!==typeof System)&&('function'===typeof System.register)&&('function'===typeof System['import']) ) /* ES6 module */
-    System.register(name,[],function($__export){$__export(name, factory.call(root));});
-else if ( ('function'===typeof define)&&define.amd&&('function'===typeof require)&&('function'===typeof require.specified)&&require.specified(name) /*&& !require.defined(name)*/ ) /* AMD */
-    define(name,['module'],function(module){factory.moduleUri = module.uri; return factory.call(root);});
-else if ( !(name in root) ) /* Browser/WebWorker/.. */
-    (root[name] = factory.call(root)||1)&&('function'===typeof(define))&&define.amd&&define(function(){return root[name];} );
-}(  /* current root */          (( ) => {
-        if ( typeof globalThis !== 'undefined' ) { return globalThis; }
-        if ( typeof self !== 'undefined' ) { return self; }
-        if ( typeof global !== 'undefined' ) { return global; }
-    })(),
-    /* module name */           "Regex",
-    /* module factory */        function ModuleFactory__Regex( undef ){
+export default (function () {
 "use strict";
 var __version__ = "1.1.0",
 
@@ -2155,4 +2139,4 @@ var Regex = {
 };
 /* export the module */
 return Regex;
-});
+})();


### PR DESCRIPTION
This patch converts the file `regex.js` into an ES module.

[RegexAnalyzer](https://github.com/foo123/RegexAnalyzer) has not been updated for two years. If it's ever updated, the integration should be easy by applying this same patch (more or less) on the new file.

```
make test-full-battery
make check-leaks
```