### PR TITLE
Convert punycode.js into an ES module

### DIFF
--- a/platform/browser/main.js
+++ b/platform/browser/main.js
@@ -24,7 +24,7 @@
 /******************************************************************************/
 
 import './lib/publicsuffixlist/publicsuffixlist.js';
-import './lib/punycode.js';
+import punycode from './lib/punycode.js';
 
 import globals from './js/globals.js';
 import staticNetFilteringEngine from './js/static-net-filtering.js';
@@ -93,7 +93,7 @@ function pslInit(raw) {
         console.info('Unable to populate public suffix list');
         return;
     }
-    globals.publicSuffixList.parse(raw, globals.punycode.toASCII);
+    globals.publicSuffixList.parse(raw, punycode.toASCII);
     console.info('Public suffix list populated');
 }
 

--- a/platform/nodejs/index.js
+++ b/platform/nodejs/index.js
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-import './lib/punycode.js';
+import punycode from './lib/punycode.js';
 import './lib/publicsuffixlist/publicsuffixlist.js';
 
 import globals from './js/globals.js';
@@ -77,7 +77,7 @@ async function enableWASM() {
 
 function pslInit(raw) {
     if ( typeof raw === 'string' && raw.trim() !== '' ) {
-        globals.publicSuffixList.parse(raw, globals.punycode.toASCII);
+        globals.publicSuffixList.parse(raw, punycode.toASCII);
         return globals.publicSuffixList;
     }
 
@@ -105,7 +105,7 @@ function pslInit(raw) {
         console.error('Unable to populate public suffix list');
         return;
     }
-    globals.publicSuffixList.parse(raw, globals.punycode.toASCII);
+    globals.publicSuffixList.parse(raw, punycode.toASCII);
     return globals.publicSuffixList;
 }
 

--- a/src/js/dynamic-net-filtering.js
+++ b/src/js/dynamic-net-filtering.js
@@ -23,7 +23,8 @@
 
 /******************************************************************************/
 
-import globals from './globals.js';
+import punycode from '../lib/punycode.js';
+
 import { LineIterator } from './text-utils.js';
 
 import {
@@ -32,8 +33,6 @@ import {
 } from './uri-utils.js';
 
 /******************************************************************************/
-
-const punycode = globals.punycode || undefined;
 
 // Object.create(null) is used below to eliminate worries about unexpected
 // property names in prototype chain -- and this way we don't have to use

--- a/src/js/hnswitches.js
+++ b/src/js/hnswitches.js
@@ -25,13 +25,13 @@
 
 /******************************************************************************/
 
-import globals from './globals.js';
+import punycode from '../lib/punycode.js';
+
 import { decomposeHostname } from './uri-utils.js';
 import { LineIterator } from './text-utils.js';
 
 /******************************************************************************/
 
-const punycode = globals.punycode || undefined;
 const decomposedSource = [];
 
 // Object.create(null) is used below to eliminate worries about unexpected

--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -24,7 +24,7 @@
 /******************************************************************************/
 
 import '../lib/publicsuffixlist/publicsuffixlist.js';
-import '../lib/punycode.js';
+import punycode from '../lib/punycode.js';
 
 import cacheStorage from './cachestorage.js';
 import cosmeticFilteringEngine from './cosmetic-filtering.js';
@@ -1087,7 +1087,6 @@ const getLists = async function(callback) {
 
 // TODO: also return origin of embedded frames?
 const getOriginHints = function() {
-    const punycode = globals.punycode;
     const out = new Set();
     for ( const tabId of µb.pageStores.keys() ) {
         if ( tabId === -1 ) { continue; }

--- a/src/js/popup-fenix.js
+++ b/src/js/popup-fenix.js
@@ -19,9 +19,11 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* global punycode, uDom */
+/* global uDom */
 
 'use strict';
+
+import punycode from '../lib/punycode.js';
 
 /******************************************************************************/
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -19,9 +19,11 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-/* global punycode, uDom */
+/* global uDom */
 
 'use strict';
+
+import punycode from '../lib/punycode.js';
 
 /******************************************************************************/
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -24,7 +24,7 @@
 /******************************************************************************/
 
 import '../lib/publicsuffixlist/publicsuffixlist.js';
-import '../lib/punycode.js';
+import punycode from '../lib/punycode.js';
 
 import cosmeticFilteringEngine from './cosmetic-filtering.js';
 import globals from './globals.js';
@@ -1244,7 +1244,7 @@ self.addEventListener('hiddenSettingsChanged', ( ) => {
 
 µb.compilePublicSuffixList = function(content) {
     const psl = globals.publicSuffixList;
-    psl.parse(content, globals.punycode.toASCII);
+    psl.parse(content, punycode.toASCII);
     io.put(`compiled/${this.pslAssetKey}`, psl.toSelfie(sparseBase64));
 };
 

--- a/src/js/uri-utils.js
+++ b/src/js/uri-utils.js
@@ -24,7 +24,7 @@
 /******************************************************************************/
 
 import '../lib/publicsuffixlist/publicsuffixlist.js';
-import '../lib/punycode.js';
+import punycode from '../lib/punycode.js';
 
 import globals from './globals.js';
 
@@ -34,7 +34,6 @@ import globals from './globals.js';
 // https://github.com/gorhill/uBlock/blob/8b5733a58d3acf9fb62815e14699c986bd1c2fdc/src/js/uritools.js
 
 const psl = globals.publicSuffixList;
-const punycode = globals.punycode;
 
 const reCommonHostnameFromURL =
     /^https?:\/\/([0-9a-z_][0-9a-z._-]*[0-9a-z])\//;

--- a/src/lib/punycode.js
+++ b/src/lib/punycode.js
@@ -1,20 +1,5 @@
 /*! https://mths.be/punycode v1.3.2 by @mathias */
-;(function(root) {
-
-	/** Detect free variables */
-	var freeExports = typeof exports == 'object' && exports &&
-		!exports.nodeType && exports;
-	var freeModule = typeof module == 'object' && module &&
-		!module.nodeType && module;
-	var freeGlobal = typeof global == 'object' && global || self;
-	if (
-		freeGlobal.global === freeGlobal ||
-		freeGlobal.window === freeGlobal ||
-		freeGlobal.self === freeGlobal
-	) {
-		root = freeGlobal;
-	}
-
+export default (function() {
 	/**
 	 * The `punycode` object.
 	 * @name punycode
@@ -504,27 +489,5 @@
 		'toUnicode': toUnicode
 	};
 
-	/** Expose `punycode` */
-	// Some AMD build optimizers, like r.js, check for specific condition patterns
-	// like the following:
-	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
-		define.amd
-	) {
-		define('punycode', function() {
-			return punycode;
-		});
-	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) { // in Node.js or RingoJS v0.8.0+
-			freeModule.exports = punycode;
-		} else { // in Narwhal or RingoJS v0.7.0-
-			for (key in punycode) {
-				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
-			}
-		}
-	} else { // in Rhino or a web browser
-		root.punycode = punycode;
-	}
-
-}(this));
+	return punycode;
+})();

--- a/src/popup-fenix.html
+++ b/src/popup-fenix.html
@@ -95,13 +95,12 @@
 </div>
 
 <script src="js/fa-icons.js"></script>
-<script src="lib/punycode.js"></script>
 <script src="js/vapi.js"></script>
 <script src="js/vapi-common.js"></script>
 <script src="js/vapi-client.js"></script>
 <script src="js/udom.js"></script>
 <script src="js/i18n.js"></script>
-<script src="js/popup-fenix.js"></script>
+<script src="js/popup-fenix.js" type="module"></script>
 
 </body>
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -62,13 +62,12 @@
 </div>
 
 <script src="js/fa-icons.js"></script>
-<script src="lib/punycode.js"></script>
 <script src="js/vapi.js"></script>
 <script src="js/vapi-common.js"></script>
 <script src="js/vapi-client.js"></script>
 <script src="js/udom.js"></script>
 <script src="js/i18n.js"></script>
-<script src="js/popup.js"></script>
+<script src="js/popup.js" type="module"></script>
 
 </body>
 

--- a/src/whitelist.html
+++ b/src/whitelist.html
@@ -43,7 +43,6 @@
 <script src="lib/codemirror/addon/scroll/annotatescrollbar.js"></script>
 <script src="lib/codemirror/addon/search/searchcursor.js"></script>
 <script src="lib/codemirror/addon/selection/active-line.js"></script>
-<script src="lib/punycode.js"></script>
 
 <script src="js/codemirror/search.js"></script>
 <script src="js/codemirror/search-thread.js"></script>


### PR DESCRIPTION
Similar rationale to #3844.

`punycode.js` is now an ES module.