### PR TITLE
Remove globals usage from background.js

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -23,7 +23,6 @@
 
 /******************************************************************************/
 
-import globals from './globals.js';
 import logger from './logger.js';
 import { FilteringContext } from './filtering-context.js';
 
@@ -337,7 +336,7 @@ const µBlock = {  // jshint ignore:line
 
 µBlock.filteringContext = new µBlock.FilteringContext();
 
-globals.µBlock = µBlock;
+self.µBlock = µBlock;
 
 /******************************************************************************/
 


### PR DESCRIPTION
This patch removes `globals` usage from `background.js`.