### PR TITLE
Fix ESLint globals error in biditrie.js

### DIFF
--- a/src/js/biditrie.js
+++ b/src/js/biditrie.js
@@ -19,6 +19,8 @@
     Home: https://github.com/gorhill/uBlock
 */
 
+/* globals WebAssembly, vAPI */
+
 'use strict';
 
 /*******************************************************************************


### PR DESCRIPTION
This fixes the ESLint error introduced in #3849.