### PR TITLE
Fix ESLint warning in useLists()

### DIFF
--- a/platform/nodejs/index.js
+++ b/platform/nodejs/index.js
@@ -180,7 +180,7 @@ async function useLists(lists, options = {}) {
 
     useLists.promise = Promise.all(promises);
     await useLists.promise;
-    useLists.promise = null;
+    useLists.promise = null; // eslint-disable-line require-atomic-updates
 
     // Commit changes
     snfe.freeze();


### PR DESCRIPTION
Fixes [require-atomic-updates](https://eslint.org/docs/rules/require-atomic-updates) warning.