### PR TITLE
Fix broken twitch.tv functionality

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -1572,7 +1572,7 @@
                 url.includes('gql') &&
                 init instanceof Object &&
                 init.headers instanceof Object &&
-                typeof init.body == 'string' &&
+                typeof init.body === 'string' &&
                 init.body.includes('PlaybackAccessToken')
             ) {
                 const { headers } = init;


### PR DESCRIPTION
Fixes some features of twitch.tv which are broken due to device id change on every gql request.

Related issues:
- https://github.com/pixeltris/TwitchAdSolutions/issues/50
- https://github.com/pixeltris/TwitchAdSolutions/issues/45