### PR TITLE
Fix applying managed storage properties in Firefox

### DIFF
--- a/src/js/start.js
+++ b/src/js/start.js
@@ -399,7 +399,12 @@ try {
     await onHiddenSettingsReady();
     ubolog(`Hidden settings ready ${Date.now()-vAPI.T0} ms after launch`);
 
-    const adminExtra = await vAPI.adminStorage.get('toAdd');
+    let toAdd = await vAPI.adminStorage.get('toAdd');
+    if (typeof toAdd === 'string' && toAdd !== '') {
+            toAdd = JSON.parse(toAdd);
+    }
+    const adminExtra = toAdd;
+    toAdd = null;
     ubolog(`Extra admin settings ready ${Date.now()-vAPI.T0} ms after launch`);
 
     // https://github.com/uBlockOrigin/uBlock-issues/issues/1365

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -128,6 +128,10 @@ import {
     const usUser = results[0] instanceof Object && results[0] ||
                    Object.assign(usDefault);
 
+    if (typeof results[1] === 'string' && results[1] !== '') {
+        results[1] = JSON.parse(results[1]);
+    }
+
     if ( Array.isArray(results[1]) ) {
         const adminSettings = results[1];
         for ( const entry of adminSettings ) {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -194,6 +194,9 @@ import {
         if (typeof results[0].advancedSettings === 'string' && results[0].advancedSettings !== '') {
             results[0].advancedSettings = JSON.parse(results[0].advancedSettings);
         }
+        if (typeof results[0].disabledPopupPanelParts === 'string' && results[0].disabledPopupPanelParts !== '') {
+            results[0].disabledPopupPanelParts = JSON.parse(results[0].disabledPopupPanelParts);
+        }
         const {
             advancedSettings,
             disableDashboard,

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -191,6 +191,9 @@ import {
     ]);
 
     if ( results[0] instanceof Object ) {
+        if (typeof results[0].advancedSettings === 'string' && results[0].advancedSettings !== '') {
+            results[0].advancedSettings = JSON.parse(results[0].advancedSettings);
+        }
         const {
             advancedSettings,
             disableDashboard,

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1387,6 +1387,8 @@ self.addEventListener('hiddenSettingsChanged', ( ) => {
         ]) || {};
         if ( store.toOverwrite instanceof Object ) {
             toOverwrite = store.toOverwrite;
+        } else if ( typeof store.toOverwrite === 'string' && store.toOverwrite !== '') {
+            toOverwrite = JSON.parse(store.toOverwrite);
         }
         const json = store.adminSettings;
         if ( typeof json === 'string' && json !== '' ) {

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -194,6 +194,9 @@ import {
         if (typeof results[0].advancedSettings === 'string' && results[0].advancedSettings !== '') {
             results[0].advancedSettings = JSON.parse(results[0].advancedSettings);
         }
+        if (typeof results[0].disableDashboard === 'number') {
+            results[0].disableDashboard = Boolean(JSON.parse(results[0].disableDashboard));
+        }
         if (typeof results[0].disabledPopupPanelParts === 'string' && results[0].disabledPopupPanelParts !== '') {
             results[0].disabledPopupPanelParts = JSON.parse(results[0].disabledPopupPanelParts);
         }


### PR DESCRIPTION
Firefox presents the properties as strings rather than the expected types like Chrome/Edge, so add a `JSON.parse()` if required. 

fixes https://github.com/uBlockOrigin/uBlock-issues/issues/2067