### PR TITLE
Add group policy templates to aid configuring in Chrome, Edge, and Firefox on Windows

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -208,7 +208,7 @@ import {
                 hsDefault[name] = hsAdmin[name] = hsUser[name] = value;
             }
         }
-        µb.noDashboard = disableDashboard === true;
+        µb.noDashboard = disableDashboard == true;
         if ( Array.isArray(disabledPopupPanelParts) ) {
             const partNameToBit = new Map([
                 [  'globalStats', 0b00010 ],

--- a/tools/GroupPolicy/en-US/uBlock.adml
+++ b/tools/GroupPolicy/en-US/uBlock.adml
@@ -11,6 +11,7 @@
             <string id="uBlockCategory">uBlock Origin</string>
             <string id="GoogleChrome">Google Chrome</string>
             <string id="MicrosoftEdge">Microsoft Edge</string>
+            <string id="MozillaFirefox">Mozilla Firefox</string>
             <string id="adminSettings">Apply an exported configuration (adminSettings)</string>
             <string id="advancedSettings">Advanced settings to overwrite</string>
             <string id="userSettings">User settings to overwrite</string>

--- a/tools/GroupPolicy/en-US/uBlock.adml
+++ b/tools/GroupPolicy/en-US/uBlock.adml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitionResources xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions" revision="1.0" schemaVersion="1.0">
+    <displayName>Contoso Company base file</displayName>
+    <description>This file contains the Contoso parent category.
+  </description>
+    <resources>
+        <stringTable>
+            <string id="V1_0_0_1">uBlock Origin v1.0.0.1 or later</string>
+            <string id="V1_3_2">uBlock Origin v1.3.2 or later</string>
+            <string id="V1_33_0">uBlock Origin v1.33.0 or later</string>
+            <string id="uBlockCategory">uBlock Origin</string>
+            <string id="GoogleChrome">Google Chrome</string>
+            <string id="MicrosoftEdge">Microsoft Edge</string>
+            <string id="adminSettings">Apply an exported configuration (adminSettings)</string>
+            <string id="advancedSettings">Advanced settings to overwrite</string>
+            <string id="userSettings">User settings to overwrite</string>
+            <string id="disableDashboard">Prevent access to uBO's dashboard</string>
+            <string id="disabledPopupPanelParts">Popup panel parts to disable</string>
+            <string id="toAdd">Settings to add at launch time</string>
+            <string id="toOverwrite">Settings to overwrite at launch time</string>
+            <string id="adminSettings_Help">A valid JSON string compliant with uBO's backup format.
+                
+Administrators can force specific configurations to deployed uBlock Origin (uBO). At launch time, uBO will look for a setting named adminSettings, and if it exists, it will parse, extract and overwrite a user's settings with the administrator-assigned ones.
+
+Configure uBO as you wish for your users, then create a backup using the "Backup to file" in the Settings pane. Now open this backup file using a text editor, and remove all entries you do not want to overwrite, while taking care to end up with a valid JSON file (mind trailing commas, etc.). All the entries left are the ones which will be overwritten on the user's side.
+
+Example value:
+{"userSettings": {"colorBlindFriendly": true}}
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin
+            </string>
+            <string id="userSettings_Help">A list of [name,value] pairs to populate user settings
+                
+Each entry in the array is an array consisting of a pair of name-value strings. Each name string must be a supported user setting, and each value string must properly resolve to a supported value.
+
+Every valid entry will be used to overwrite the corresponding default user setting at launch time.
+
+Example value:
+[[ "contextMenuEnabled", "false" ],[ "dynamicFilteringEnabled", "false" ]]
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#usersettings</string>
+            <string id="advancedSettings_Help">A list of [name,value] pairs to populate advanced settings
+                
+Each entry in the array is an array consisting of a pair of name-value strings. Each name string must be a supported advanced setting, and each value string must properly resolve to a supported value.
+
+Every valid entry will be used to overwrite the corresponding default advanced setting, and will also become read-only, i.e. the user won't be able to change it.
+
+Example value:
+[[ "disableWebAssembly", "true" ]]
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#advancedsettings</string>
+            <string id="disableDashboard_Help">Set to true to prevent access to configuration options
+                
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#disabledashboard</string>
+            <string id="disabledPopupPanelParts_Help">An array of strings, where each string refer to a part of the popup panel which should be removed from view. Current supported named parts:
+
+globalStats: remove access to "Blocked since install" statistic.
+basicTools: remove access to basic tools.
+extraTools: remove access to per-site switches.
+overviewPane: remove access to the overview pane.
+
+Example value:
+["globalStats","overviewPane"]
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#disabledpopuppanelparts</string>
+            <string id="toAdd_Help">The properties in the toAdd branch will append to the already present local settings. Currently, the following properties are supported:
+
+trustedSiteDirectives
+The trustedSiteDirectives property is an array of string, each of which must resolve into a valid trusted-site directive, used to dictate where uBO must be disabled.
+
+Example value:
+{"trustedSiteDirectives": ["example.com","example.org"]}
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#toadd</string>
+            <string id="toOverwrite_Help">The properties in the toOverwrite branch will wholly replace the corresponding local settings. Currently, the following properties are supported:
+
+filters
+The filters property is an array of strings, which are meant to represent all the lines making the text to use as the content of the "My filters" pane.
+
+filterLists
+The filterLists property is an array of strings, where each string is a token which identifies a list to enable by default. To enable a stock filter list, this is the token identifying the list as per content of assets.json. For an external list, i.e. not found in assets.json, the token is the URL of the filter list.
+
+trustedSiteDirectives
+The trustedSiteDirectives property is an array of string, each of which must resolve into a valid trusted-site directive, used to dictate where uBO must be disabled.
+
+All the directives will be used to wholly replace the local trusted-site directives, including the built-in ones.
+
+Example value:
+{"trustedSiteDirectives": ["example.com","example.org"], "filters": ["||example.com/log$xhr,domain=www.example.org"], "filterLists": ["ublock-filters"]}
+
+https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#tooverwrite</string>
+        </stringTable>
+        <presentationTable>
+            <presentation id="adminSettings">
+                <textBox refId="adminSettingsDialog">
+                    <label>Exported settings to apply:</label>
+                </textBox>
+            </presentation>
+            <presentation id="advancedSettings">
+                <textBox refId="advancedSettingsDialog">
+                    <label>Advanced settings to set:</label>
+                </textBox>
+            </presentation>
+            <presentation id="userSettings">
+                <textBox refId="userSettingsDialog">
+                    <label>User settings to set:</label>
+                </textBox>
+            </presentation>
+            <presentation id="disabledPopupPanelParts">
+                <textBox refId="disabledPopupPanelPartsDialog">
+                    <label>Popup panel parts to disable:</label>
+                </textBox>
+            </presentation>
+            <presentation id="toAdd">
+                <textBox refId="toAddDialog">
+                    <label>Properties to add:</label>
+                </textBox>
+            </presentation>
+            <presentation id="toOverwrite">
+                <textBox refId="toOverwriteDialog">
+                    <label>Properties to overwrite:</label>
+                </textBox>
+            </presentation>
+        </presentationTable>
+    </resources>
+</policyDefinitionResources>

--- a/tools/GroupPolicy/en-US/uBlock.adml
+++ b/tools/GroupPolicy/en-US/uBlock.adml
@@ -122,6 +122,21 @@ https://github.com/gorhill/uBlock/wiki/Deploying-uBlock-Origin:-configuration#to
                     <label>Properties to overwrite:</label>
                 </textBox>
             </presentation>
+            <presentation id="advancedSettingsMulti">
+                <multiTextBox refId="advancedSettingsDialogMulti" />
+            </presentation>
+            <presentation id="userSettingsMulti">
+                <multiTextBox refId="userSettingsDialogMulti" />
+            </presentation>
+            <presentation id="disabledPopupPanelPartsMulti">
+                <multiTextBox refId="disabledPopupPanelPartsDialogMulti" />
+            </presentation>
+            <presentation id="toAddMulti">
+                <multiTextBox refId="toAddDialogMulti" />
+            </presentation>
+            <presentation id="toOverwriteMulti">
+                <multiTextBox refId="toOverwriteDialogMulti" />
+            </presentation>
         </presentationTable>
     </resources>
 </policyDefinitionResources>

--- a/tools/GroupPolicy/uBlock.admx
+++ b/tools/GroupPolicy/uBlock.admx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitions xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
+    <policyNamespaces>
+        <target prefix="uBlock" namespace="gorhill.uBlock" />
+    </policyNamespaces>
+    <resources minRequiredRevision="1.0" />
+    <supportedOn>
+        <definitions>
+            <definition name="V1_33_0" displayName="$(string.V1_33_0)" />
+            <definition name="V1_0_0_1" displayName="$(string.V1_0_0_1)" />
+        </definitions>
+    </supportedOn>
+    <categories>
+        <category name="uBlockOrigin" displayName="$(string.uBlockCategory)" />
+        <category name="MicrosoftEdge" displayName="$(string.MicrosoftEdge)">
+            <parentCategory ref="uBlockOrigin" />
+        </category>
+    </categories>
+    <policies>
+        <policy name="edgeAdminSettings" class="Both" displayName="$(string.adminSettings)" explainText="$(string.adminSettings_Help)" presentation="$(presentation.adminSettings)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_0_0_1" />
+            <elements>
+                <text id="adminSettingsDialog" valueName="adminSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="edgeAdvancedSettings" class="Both" displayName="$(string.advancedSettings)" explainText="$(string.advancedSettings_Help)" presentation="$(presentation.advancedSettings)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="advancedSettingsDialog" valueName="advancedSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="edgeUserSettings" class="Both" displayName="$(string.userSettings)" explainText="$(string.userSettings_Help)" presentation="$(presentation.userSettings)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="userSettingsDialog" valueName="userSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="edgeDisableDashboard" class="Both" displayName="$(string.disableDashboard)" explainText="$(string.disableDashboard_Help)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy" valueName="disableDashboard">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+        </policy>
+        <policy name="edgeDisabledPopupPanelParts" class="Both" displayName="$(string.disabledPopupPanelParts)" explainText="$(string.disabledPopupPanelParts_Help)" presentation="$(presentation.disabledPopupPanelParts)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="disabledPopupPanelPartsDialog" valueName="disabledPopupPanelParts" required="true" />
+            </elements>
+        </policy>
+        <policy name="edgeToAdd" class="Both" displayName="$(string.toAdd)" explainText="$(string.toAdd_Help)" presentation="$(presentation.toAdd)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toAddDialog" valueName="toAdd" required="true" />
+            </elements>
+        </policy>
+        <policy name="edgeToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwrite)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
+            <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />
+            </elements>
+        </policy>
+    </policies>
+</policyDefinitions>

--- a/tools/GroupPolicy/uBlock.admx
+++ b/tools/GroupPolicy/uBlock.admx
@@ -122,5 +122,44 @@
                 <text id="adminSettingsDialog" valueName="adminSettings" required="true" />
             </elements>
         </policy>
+        <policy name="firefoxAdvancedSettings" class="Both" displayName="$(string.advancedSettings)" explainText="$(string.advancedSettings_Help)" presentation="$(presentation.advancedSettings)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="advancedSettingsDialog" valueName="advancedSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="firefoxUserSettings" class="Both" displayName="$(string.userSettings)" explainText="$(string.userSettings_Help)" presentation="$(presentation.userSettings)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="userSettingsDialog" valueName="userSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="firefoxDisableDashboard" class="Both" displayName="$(string.disableDashboard)" explainText="$(string.disableDashboard_Help)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net" valueName="disableDashboard">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+        </policy>
+        <policy name="firefoxDisabledPopupPanelParts" class="Both" displayName="$(string.disabledPopupPanelParts)" explainText="$(string.disabledPopupPanelParts_Help)" presentation="$(presentation.disabledPopupPanelParts)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="disabledPopupPanelPartsDialog" valueName="disabledPopupPanelParts" required="true" />
+            </elements>
+        </policy>
+        <policy name="firefoxToAdd" class="Both" displayName="$(string.toAdd)" explainText="$(string.toAdd_Help)" presentation="$(presentation.toAdd)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toAddDialog" valueName="toAdd" required="true" />
+            </elements>
+        </policy>
+        <policy name="firefoxToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwrite)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />
+            </elements>
+        </policy>
     </policies>
 </policyDefinitions>

--- a/tools/GroupPolicy/uBlock.admx
+++ b/tools/GroupPolicy/uBlock.admx
@@ -122,43 +122,43 @@
                 <text id="adminSettingsDialog" valueName="adminSettings" required="true" />
             </elements>
         </policy>
-        <policy name="firefoxAdvancedSettings" class="Both" displayName="$(string.advancedSettings)" explainText="$(string.advancedSettings_Help)" presentation="$(presentation.advancedSettings)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+        <policy name="firefoxAdvancedSettings" class="Both" displayName="$(string.advancedSettings)" explainText="$(string.advancedSettings_Help)" presentation="$(presentation.advancedSettingsMulti)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
             <elements>
-                <text id="advancedSettingsDialog" valueName="advancedSettings" required="true" />
+                <multiText id="advancedSettingsDialogMulti" valueName="advancedSettings" required="true" maxStrings="1" />
             </elements>
         </policy>
-        <policy name="firefoxUserSettings" class="Both" displayName="$(string.userSettings)" explainText="$(string.userSettings_Help)" presentation="$(presentation.userSettings)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+        <policy name="firefoxUserSettings" class="Both" displayName="$(string.userSettings)" explainText="$(string.userSettings_Help)" presentation="$(presentation.userSettingsMulti)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
             <elements>
-                <text id="userSettingsDialog" valueName="userSettings" required="true" />
+                <multiText id="userSettingsDialogMulti" valueName="userSettings" required="true" maxStrings="1" />
             </elements>
         </policy>
         <policy name="firefoxDisableDashboard" class="Both" displayName="$(string.disableDashboard)" explainText="$(string.disableDashboard_Help)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net" valueName="disableDashboard">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
         </policy>
-        <policy name="firefoxDisabledPopupPanelParts" class="Both" displayName="$(string.disabledPopupPanelParts)" explainText="$(string.disabledPopupPanelParts_Help)" presentation="$(presentation.disabledPopupPanelParts)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+        <policy name="firefoxDisabledPopupPanelParts" class="Both" displayName="$(string.disabledPopupPanelParts)" explainText="$(string.disabledPopupPanelParts_Help)" presentation="$(presentation.disabledPopupPanelPartsMulti)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
             <elements>
-                <text id="disabledPopupPanelPartsDialog" valueName="disabledPopupPanelParts" required="true" />
+                <multiText id="disabledPopupPanelPartsDialogMulti" valueName="disabledPopupPanelParts" required="true" maxStrings="1" />
             </elements>
         </policy>
-        <policy name="firefoxToAdd" class="Both" displayName="$(string.toAdd)" explainText="$(string.toAdd_Help)" presentation="$(presentation.toAdd)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+        <policy name="firefoxToAdd" class="Both" displayName="$(string.toAdd)" explainText="$(string.toAdd_Help)" presentation="$(presentation.toAddMulti)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
             <elements>
-                <text id="toAddDialog" valueName="toAdd" required="true" />
+                <multiText id="toAddDialogMulti" valueName="toAdd" required="true" maxStrings="1" />
             </elements>
         </policy>
-        <policy name="firefoxToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwrite)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+        <policy name="firefoxToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwriteMulti)" key="Software\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
             <parentCategory ref="MozillaFirefox" />
             <supportedOn ref="V1_33_0" />
             <elements>
-                <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />
+                <multiText id="toOverwriteDialogMulti" valueName="toOverwrite" required="true" maxStrings="1" />
             </elements>
         </policy>
     </policies>

--- a/tools/GroupPolicy/uBlock.admx
+++ b/tools/GroupPolicy/uBlock.admx
@@ -18,6 +18,9 @@
         <category name="GoogleChrome" displayName="$(string.GoogleChrome)">
             <parentCategory ref="uBlockOrigin" />
         </category>
+        <category name="MozillaFirefox" displayName="$(string.MozillaFirefox)">
+            <parentCategory ref="uBlockOrigin" />
+        </category>
     </categories>
     <policies>
         <policy name="edgeAdminSettings" class="Both" displayName="$(string.adminSettings)" explainText="$(string.adminSettings_Help)" presentation="$(presentation.adminSettings)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
@@ -110,6 +113,13 @@
             <supportedOn ref="V1_33_0" />
             <elements>
                 <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />
+            </elements>
+        </policy>
+        <policy name="firefoxAdminSettings" class="Both" displayName="$(string.adminSettings)" explainText="$(string.adminSettings_Help)" presentation="$(presentation.adminSettings)" key="SOFTWARE\Policies\Mozilla\Firefox\3rdparty\Extensions\uBlock0@raymondhill.net">
+            <parentCategory ref="MozillaFirefox" />
+            <supportedOn ref="V1_0_0_1" />
+            <elements>
+                <text id="adminSettingsDialog" valueName="adminSettings" required="true" />
             </elements>
         </policy>
     </policies>

--- a/tools/GroupPolicy/uBlock.admx
+++ b/tools/GroupPolicy/uBlock.admx
@@ -15,6 +15,9 @@
         <category name="MicrosoftEdge" displayName="$(string.MicrosoftEdge)">
             <parentCategory ref="uBlockOrigin" />
         </category>
+        <category name="GoogleChrome" displayName="$(string.GoogleChrome)">
+            <parentCategory ref="uBlockOrigin" />
+        </category>
     </categories>
     <policies>
         <policy name="edgeAdminSettings" class="Both" displayName="$(string.adminSettings)" explainText="$(string.adminSettings_Help)" presentation="$(presentation.adminSettings)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
@@ -58,6 +61,52 @@
         </policy>
         <policy name="edgeToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwrite)" key="Software\Policies\Microsoft\Edge\3rdparty\Extensions\odfafepnkmbhccpbejgmiehpchacaeak\policy">
             <parentCategory ref="MicrosoftEdge" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeAdminSettings" class="Both" displayName="$(string.adminSettings)" explainText="$(string.adminSettings_Help)" presentation="$(presentation.adminSettings)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_0_0_1" />
+            <elements>
+                <text id="adminSettingsDialog" valueName="adminSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeAdvancedSettings" class="Both" displayName="$(string.advancedSettings)" explainText="$(string.advancedSettings_Help)" presentation="$(presentation.advancedSettings)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="advancedSettingsDialog" valueName="advancedSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeUserSettings" class="Both" displayName="$(string.userSettings)" explainText="$(string.userSettings_Help)" presentation="$(presentation.userSettings)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="userSettingsDialog" valueName="userSettings" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeDisableDashboard" class="Both" displayName="$(string.disableDashboard)" explainText="$(string.disableDashboard_Help)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy" valueName="disableDashboard">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_33_0" />
+        </policy>
+        <policy name="chromeDisabledPopupPanelParts" class="Both" displayName="$(string.disabledPopupPanelParts)" explainText="$(string.disabledPopupPanelParts_Help)" presentation="$(presentation.disabledPopupPanelParts)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="disabledPopupPanelPartsDialog" valueName="disabledPopupPanelParts" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeToAdd" class="Both" displayName="$(string.toAdd)" explainText="$(string.toAdd_Help)" presentation="$(presentation.toAdd)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
+            <supportedOn ref="V1_33_0" />
+            <elements>
+                <text id="toAddDialog" valueName="toAdd" required="true" />
+            </elements>
+        </policy>
+        <policy name="chromeToOverwrite" class="Both" displayName="$(string.toOverwrite)" explainText="$(string.toOverwrite_Help)" presentation="$(presentation.toOverwrite)" key="Software\Policies\Google\Chrome\3rdparty\Extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\policy">
+            <parentCategory ref="GoogleChrome" />
             <supportedOn ref="V1_33_0" />
             <elements>
                 <text id="toOverwriteDialog" valueName="toOverwrite" required="true" />


### PR DESCRIPTION
Group policy administrative templates describe settings and the UI for configuring them for administrators using Group Policy on Windows computers, and to a lesser extent serve as documentation for the registry settings used. This PR adds a template, and an English language file using descriptions of settings and examples from the wiki, to configure uBlock in Chrome, Edge, and Firefox.

The folder location seemed sensible since the files would not need to be deployed with the application, more likely an admin would download them from github to import and use, so please say if there's a preferable one.

The change to storage.js to allow truth-y values for `disableDashboard` is intentional - without this, it's more complicated to configure `disableDashboard` via the registry for Firefox (the other browsers don't need this), and would prevent using a simple enable/disable policy. If needed, this could be removed or moved to a separate PR.