### PR TITLE
Adding "LKA" for Sri Lanka and "NPL" for Nepal to IndianList's title

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -470,7 +470,7 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "IND, LKA: IndianList",
+		"title": "IND, LKA, NPL: IndianList",
 		"lang": "as bn gu hi kn ml mr ne pa si ta te",
 		"contentURL": "https://easylist-downloads.adblockplus.org/indianlist.txt",
 		"supportURL": "https://github.com/mediumkreation/IndianList"

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -470,7 +470,7 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "IND: IndianList",
+		"title": "IND, LKA: IndianList",
 		"lang": "as bn gu hi kn ml mr ne pa si ta te",
 		"contentURL": "https://easylist-downloads.adblockplus.org/indianlist.txt",
 		"supportURL": "https://github.com/mediumkreation/IndianList"


### PR DESCRIPTION
I approve of the (seemingly recent) inclusion of IndianList in uBlock Origin, and I figured I could add "LKA" for Sri Lanka to the title, since the list also happens to cover Sri Lanka's two main languages (Sinhala and Tamil), and I know of at least one Sri Lankan website (`ada.lk`) that IndianList has entries for.

As for "NPL" for Nepal, I've got confirmation that not just Nepali, but also Maithili (Nepal's two biggest languages) are supported, as per https://github.com/mediumkreation/IndianList/issues/5063#issuecomment-1109982902