### PR TITLE
fix(curben-filter): curben.gitlab.io migrated to malware-filter.gitlab.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Mozilla Add-ons](https://img.shields.io/amo/rating/ublock-origin?label=Firefox)](https://addons.mozilla.org/firefox/addon/ublock-origin/)
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/rating/cjpalhdlnbpafiamejdnhcphjbkeiagm?label=Chrome)](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)
 
-*** 
+***
 
 <h1 align="center">
 <sub>
@@ -25,7 +25,7 @@ uBlock Origin
 ***
 
 <p align="center">
-<a href="https://addons.mozilla.org/firefox/addon/ublock-origin/"><img src="https://user-images.githubusercontent.com/585534/107280546-7b9b2a00-6a26-11eb-8f9f-f95932f4bfec.png" alt="Get uBlock Origin for Firefox"></a> 
+<a href="https://addons.mozilla.org/firefox/addon/ublock-origin/"><img src="https://user-images.githubusercontent.com/585534/107280546-7b9b2a00-6a26-11eb-8f9f-f95932f4bfec.png" alt="Get uBlock Origin for Firefox"></a>
 <a href="https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm"><img src="https://user-images.githubusercontent.com/585534/107280622-91a8ea80-6a26-11eb-8d07-77c548b28665.png" alt="Get uBlock Origin for Chromium"></a>
 <a href="https://microsoftedge.microsoft.com/addons/detail/ublock-origin/odfafepnkmbhccpbejgmiehpchacaeak"><img src="https://user-images.githubusercontent.com/585534/107280673-a5ece780-6a26-11eb-9cc7-9fa9f9f81180.png" alt="Get uBlock Origin for Microsoft Edge"></a>
 <a href="https://addons.opera.com/extensions/details/ublock/"><img src="https://user-images.githubusercontent.com/585534/107280692-ac7b5f00-6a26-11eb-85c7-088926504452.png" alt="Get uBlock Origin for Opera"></a>
@@ -37,7 +37,7 @@ uBlock Origin
 
 **An efficient blocker add-on for various browsers. Fast, potent, and lean.**
 
-uBlock Origin is **NOT** an "ad blocker": [it is a wide-spectrum blocker](https://github.com/gorhill/uBlock/wiki/Blocking-mode) -- which happens to be able to function as a mere "ad blocker". The default behavior of uBlock Origin when newly installed is to block ads, trackers and malware sites -- through [_EasyList_](https://easylist.github.io/#easylist), [_EasyPrivacy_](https://easylist.github.io/#easyprivacy), [_Peter Lowe’s ad/tracking/malware servers_](https://pgl.yoyo.org/adservers/policy.php), [_Online Malicious URL Blocklist_](https://gitlab.com/curben/urlhaus-filter#urlhaus-malicious-url-blocklist), and uBlock Origin's [own filter lists](https://github.com/uBlockOrigin/uAssets/tree/master/filters).
+uBlock Origin is **NOT** an "ad blocker": [it is a wide-spectrum blocker](https://github.com/gorhill/uBlock/wiki/Blocking-mode) -- which happens to be able to function as a mere "ad blocker". The default behavior of uBlock Origin when newly installed is to block ads, trackers and malware sites -- through [_EasyList_](https://easylist.github.io/#easylist), [_EasyPrivacy_](https://easylist.github.io/#easyprivacy), [_Peter Lowe’s ad/tracking/malware servers_](https://pgl.yoyo.org/adservers/policy.php), [_Online Malicious URL Blocklist_](https://gitlab.com/malware-filter/urlhaus-filter#urlhaus-malicious-url-blocklist), and uBlock Origin's [own filter lists](https://github.com/uBlockOrigin/uAssets/tree/master/filters).
 
 ***
 
@@ -56,7 +56,7 @@ uBlock Origin is **NOT** an "ad blocker": [it is a wide-spectrum blocker](https:
 
  Basic mode | Advanced-user mode
 :----------:|:------------------:
-[Popup user interface](https://github.com/gorhill/uBlock/wiki/Quick-guide:-popup-user-interface) | [A point-and-click firewall which can be configured on a per-site basis](https://github.com/gorhill/uBlock/wiki/Dynamic-filtering:-quick-guide) 
+[Popup user interface](https://github.com/gorhill/uBlock/wiki/Quick-guide:-popup-user-interface) | [A point-and-click firewall which can be configured on a per-site basis](https://github.com/gorhill/uBlock/wiki/Dynamic-filtering:-quick-guide)
 <a href="https://github.com/gorhill/uBlock/wiki/Quick-guide:-popup-user-interface"><img src="https://user-images.githubusercontent.com/585534/84045360-b10ee580-a976-11ea-9e91-29c2107b47c2.png" /></a><br><sup>.<br>.</sup> | <a href="https://github.com/gorhill/uBlock/wiki/Dynamic-filtering:-quick-guide"><img src="https://user-images.githubusercontent.com/585534/84045366-b1a77c00-a976-11ea-9121-e8c8f35c66c8.png" /></a><br><sup>Configure as you wish:<br>picture shows 3rd-party scripts and frames blocked by default everywhere</sup>
 
 Visit the [uBlock Origin's wiki](https://github.com/gorhill/uBlock/wiki) for documentation.

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -230,41 +230,41 @@
 		"group": "malware",
 		"title": "Online Malicious URL Blocklist",
 		"contentURL": [
-			"https://curben.gitlab.io/malware-filter/urlhaus-filter-online.txt",
+			"https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-online.txt",
 			"assets/thirdparties/urlhaus-filter/urlhaus-filter-online.txt"
 		],
 		"cdnURLs": [
 			"https://curbengh.github.io/malware-filter/urlhaus-filter-online.txt",
-			"https://curben.gitlab.io/urlhaus-filter/urlhaus-filter-online.txt",
+			"https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-online.txt",
 			"https://malware-filter.pages.dev/urlhaus-filter-online.txt"
 		],
-		"supportURL": "https://gitlab.com/curben/urlhaus-filter#malicious-url-blocklist"
+		"supportURL": "https://gitlab.com/malware-filter/urlhaus-filter#malicious-url-blocklist"
 	},
 	"curben-phishing": {
 		"content": "filters",
 		"group": "malware",
 		"off": true,
 		"title": "Phishing URL Blocklist",
-		"contentURL": "https://curben.gitlab.io/malware-filter/phishing-filter.txt",
+		"contentURL": "https://malware-filter.gitlab.io/malware-filter/phishing-filter.txt",
 		"cdnURLs": [
 			"https://curbengh.github.io/phishing-filter/phishing-filter.txt",
-			"https://curben.gitlab.io/phishing-filter/phishing-filter.txt",
+			"https://malware-filter.gitlab.io/phishing-filter/phishing-filter.txt",
 			"https://phishing-filter.pages.dev/phishing-filter.txt"
 		],
-		"supportURL": "https://gitlab.com/curben/phishing-filter#phishing-url-blocklist"
+		"supportURL": "https://gitlab.com/malware-filter/phishing-filter#phishing-url-blocklist"
 	},
 	"curben-pup": {
 		"content": "filters",
 		"group": "malware",
 		"off": true,
 		"title": "PUP Domains Blocklist",
-		"contentURL": "https://curben.gitlab.io/malware-filter/pup-filter.txt",
+		"contentURL": "https://malware-filter.gitlab.io/malware-filter/pup-filter.txt",
 		"cdnURLs": [
 			"https://curbengh.github.io/pup-filter/pup-filter.txt",
-			"https://curben.gitlab.io/pup-filter/pup-filter.txt",
+			"https://malware-filter.gitlab.io/pup-filter/pup-filter.txt",
 			"https://pup-filter.pages.dev/pup-filter.txt"
 		],
-		"supportURL": "https://gitlab.com/curben/pup-filter#pup-domains-blocklist"
+		"supportURL": "https://gitlab.com/malware-filter/pup-filter#pup-domains-blocklist"
 	},
 	"adguard-annoyance": {
 		"content": "filters",


### PR DESCRIPTION
migrated gitlab.com/curben/ to gitlab.com/malware-filter/ to avoid [gitlab quota](https://about.gitlab.com/blog/2021/11/11/public-project-minute-limits).