### PR TITLE
Added an attempted CDN for 'Latvian List'

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -562,6 +562,7 @@
 		"title": "LVA: Latvian List",
 		"lang": "lv",
 		"contentURL": "https://notabug.org/latvian-list/adblock-latvian/raw/master/lists/latvian-list.txt",
+		"cdnURLs": "https://cdn.statically.io/gl/DandelionSprout/LatvianListBackup/master/lists/latvian-list.txt",
 		"supportURL": "https://notabug.org/latvian-list/adblock-latvian"
 	},
 	"NLD-0": {


### PR DESCRIPTION
I've heard rumours in the past couple weeks that there are severe uptime issues for Latvian List (which doesn't surprise me, considering how bad of a site NotABug is), such that several adblockers (esp. AdGuard) were considering removing that list altogether.

So I decided to set up a NotABug→GitLab unofficial mirror, in partial coordination with Edivania Dias from Eyeo; with the future option of changing the mirror into a fork if Latvian List's maintainer continues to be AFK.