### PR TITLE
Add the new uBO versions of Fanboy's Annoyance and Cookie

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -297,7 +297,7 @@
 		"group": "social",
 		"off": true,
 		"title": "Fanboy’s Annoyance",
-		"contentURL": "https://secure.fanboy.co.nz/fanboy-annoyance.txt",
+		"contentURL": "https://secure.fanboy.co.nz/fanboy-annoyance_ubo.txt",
 		"supportURL": "https://easylist.to/"
 	},
 	"fanboy-cookiemonster": {
@@ -305,7 +305,7 @@
 		"group": "social",
 		"off": true,
 		"title": "EasyList Cookie",
-		"contentURL": "https://secure.fanboy.co.nz/fanboy-cookiemonster.txt",
+		"contentURL": "https://secure.fanboy.co.nz/fanboy-cookiemonster_ubo.txt",
 		"supportURL": "https://github.com/easylist/easylist/issues"
 	},
 	"fanboy-social": {


### PR DESCRIPTION
Fanboy appears to have split his annoyances lists into uBO- and ABP-targeting versions, with the former having considerably more entries from I can determine at a surface glance when it comes to Annoyance (84,197 vs 74,607, ±500).

And although there hasn't been much fanfare or announcements of that split, I can only presume that Fanboy wishes for uBO users to use the new uBO list versions.