### PR TITLE
Use safe Function.prototype.toString() in scriptlets

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -62,6 +62,7 @@ function safeSelf() {
         'fetch': self.fetch,
         'JSON_parse': self.JSON.parse.bind(self.JSON),
         'JSON_stringify': self.JSON.stringify.bind(self.JSON),
+        'toString': self.Function.prototype.toString,
         'log': console.log.bind(console),
         uboLog(...args) {
             if ( scriptletGlobals.has('canDebug') === false ) { return; }
@@ -1375,7 +1376,7 @@ function addEventListenerDefuser(
                 let type, handler;
                 try {
                     type = String(args[0]);
-                    handler = String(args[1]);
+                    handler = safe.toString.call(args[1]);
                 } catch(ex) {
                 }
                 const matchesType = safe.RegExp_test.call(reType, type);
@@ -1624,7 +1625,7 @@ function adjustSetInterval(
             const [ a, b ] = args;
             if (
                 (delay === -1 || b === delay) &&
-                reNeedle.test(a.toString())
+                reNeedle.test(safe.toString.call(a))
             ) {
                 args[1] = b * boost;
             }
@@ -1678,7 +1679,7 @@ function adjustSetTimeout(
             const [ a, b ] = args;
             if (
                 (delay === -1 || b === delay) &&
-                reNeedle.test(a.toString())
+                reNeedle.test(safe.toString.call(a))
             ) {
                 args[1] = b * boost;
             }
@@ -1708,7 +1709,7 @@ function noEvalIf(
     window.eval = new Proxy(window.eval, {  // jshint ignore: line
         apply: function(target, thisArg, args) {
             const a = args[0];
-            if ( reNeedle.test(a.toString()) ) { return; }
+            if ( reNeedle.test(safe.toString.call(a)) ) { return; }
             return target.apply(thisArg, args);
         }
     });
@@ -2053,7 +2054,7 @@ function noSetIntervalIf(
     const reNeedle = safe.patternToRegex(needle);
     self.setInterval = new Proxy(self.setInterval, {
         apply: function(target, thisArg, args) {
-            const a = String(args[0]);
+            const a = safe.toString.call(args[0]);
             const b = args[1];
             if ( log !== undefined ) {
                 log('uBO: setInterval("%s", %s)', a, b);
@@ -2115,7 +2116,7 @@ function noSetTimeoutIf(
     const reNeedle = safe.patternToRegex(needle);
     self.setTimeout = new Proxy(self.setTimeout, {
         apply: function(target, thisArg, args) {
-            const a = String(args[0]);
+            const a = safe.toString.call(args[0]);
             const b = args[1];
             if ( log !== undefined ) {
                 log('uBO: setTimeout("%s", %s)', a, b);


### PR DESCRIPTION
Some sites (or libraries) tamper with `Function.prototype.toString` which is used in these scriptlets to match against the handler function:
`addEventListener-defuser`, `no-setInterval-if`, `no-setTimeout-if`, `adjustSetInterval`, `adjustSetTimeout`, `noeval-if`


### Example 1

Add:
```adb
noorlib.ir##+js(aeld, copy, dontMatch, log, 2)
```
Visit:
`https://noorlib.ir/book/view/30999?pageNumber=10&viewType=pdf`
See in console:
```
[uBO] addEventListener('copy', function() {
    [native code]
})
```

Use this userscript:
```js
(function() {
  const safe = {
    'toString': self.Function.prototype.toString,
    'log': console.log.bind(console)
  }

  self.EventTarget.prototype.addEventListener = new Proxy(self.EventTarget.prototype.addEventListener, {
    apply(target, thisArg, args) {
      const originalToString = String(args[1]);
      const safeToString = safe.toString.call(args[1]);
      if (originalToString !== safeToString && args[0] === 'copy') {
        safe.log(`${args[0]}\n\n[Original toString] ${originalToString}\n\n[Safe toString] ${safeToString}`)
      };
      return Reflect.apply(target, thisArg, args);
    }
  });
}) ();
```
See in console:
```js
function(){var r=Array.prototype.slice.call(arguments);try{n&&"function"==typeof n&&n.apply(this,arguments);var o=r.map((function(t){return _e(t,e)}));return t.apply(this,o)}catch(t){throw ye+=1,setTimeout((function(){ye-=1})),H((function(n){n.addEventProcessor((function(t){return e.mechanism&&(Object(y.b)(t,void 0,void 0),Object(y.a)(t,e.mechanism)),t.extra=Object(a.a)(Object(a.a)({},t.extra),{arguments:r}),t})),D(t)})),t}}
```

The tampered `toString()`:
```js
function(){for(var t=[],e=0;e<arguments.length;e++)t[e]=arguments[e];var n=Object(O.f)(this)||this;return He.apply(n,t)}
```

### Example 2

On `soft98.ir`, enter in console:
```js
(() => {}).toString()
```
See "function() { [native code] }" instead of "() => {}".

The tampered `toString()`:
```js
"function(){return en()}"
```

### Example 3
On `extremereportbot.com`, enter in console:
```js
iframe = document.createElement('iframe'); document.body.appendChild(iframe); safeToString = iframe.contentWindow.Function.prototype.toString; console.log(safeToString.call(Function.prototype.toString))
```
See `function toString(){return"function"==typeof this&&this[a]||e.call(this)}` instead of `"function toString() {
    [native code]
}"`

PR is for convenience.
