### PR TITLE
Add t/f (aka true/false) to set-cookie

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3384,7 +3384,7 @@ function setCookie(
         'enabled', 'disabled',
         'ok',
         'on', 'off',
-        'true', 'false',
+        'true', 't', 'false', 'f',
         'y', 'n',
         'yes', 'no',
     ];


### PR DESCRIPTION
Allow `t` and `f`, alias for true and false.

Used on `https://www.empik.com/`

`empik.com##+js(set-cookie, cvc, T)`