### PR TITLE
Attempted to increase the "lists too many" treshold

### DIFF
--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -1492,7 +1492,7 @@ const getSupportData = async function() {
         addedListset = undefined;
     } else {
         const added = Object.keys(addedListset);
-        const truncated = added.slice(12);
+        const truncated = added.slice(25);
         for ( const key of truncated ) {
             delete addedListset[key];
         }


### PR DESCRIPTION
In large part inspired by https://github.com/DandelionSprout/adfilt/issues/960, it has turned out that a limit of 12 added lists in the User Support settings info is unfortunately too low for at least me. The result of the limit was that I had no idea if that reporter had Frellwit's Filters turned on or not, and I take an unqualified guess that Frellwit was unsure too.

So I attempted to increase it from 12 to 25. 20 didn't feel like enough, while 30 would seem like a pretty big change for a PR.

I don't *think* this change will affect anyone else's filterlist maintenances, so I hope that this is indeed suited as a PR. On request, I could set up a uBlock-issues thread connected to this PR for broader communications and such.