### PR TITLE
Add AdRequest.omidAccessModeRules property to google-ima shim

### DIFF
--- a/src/web_accessible_resources/google-ima.js
+++ b/src/web_accessible_resources/google-ima.js
@@ -15,6 +15,7 @@
  * - Corrected typo in `UniversalAdIdInfo.getAdIdValue()` method name
  * - Corrected dispatch of LOAD event when preloading is enabled
  * - Corrected dispatch of CONTENT_PAUSE/RESUME_REQUESTED events
+ * - Added missing `AdsRequest.omidAccessModeRules` property
  * 
  * Related issue:
  * - https://github.com/uBlockOrigin/uBlock-issues/issues/2158
@@ -488,6 +489,9 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
   class AdsRenderingSettings {}
 
   class AdsRequest {
+    constructor() {
+      this.omidAccessModeRules = {};
+    }
     setAdWillAutoPlay() {}
     setAdWillPlayMuted() {}
     setContinuousPlayback() {}


### PR DESCRIPTION
Add the missing AdRequest.omidAccessModeRules[1] property, to avoid
breaking websites that access it.

1 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdsRequest#omidAccessModeRules