### PR TITLE
Cover agree set-cookie options

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3471,6 +3471,7 @@ function setCookie(
         'necessary', 'required',
         'agree', 'agreed',
         'disagree', 'disagreed',
+        'ja', 'nein', 'kein',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);

--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3472,6 +3472,7 @@ function setCookie(
         'agree', 'agreed',
         'disagree', 'disagreed',
         'ja', 'nein', 'kein',
+        'alle',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);

--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3469,6 +3469,8 @@ function setCookie(
         'true', 't', 'false', 'f',
         'yes', 'y', 'no', 'n',
         'necessary', 'required',
+        'agree', 'agreed',
+        'disagree', 'disagreed',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);

--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -903,6 +903,8 @@ function setLocalStorageItemFn(
         'false', 'true',
         'on', 'off',
         'yes', 'no',
+        'accept', 'reject',
+        'accepted', 'rejected', 'notaccepted',
         '{}', '[]', '""',
         '$remove$',
     ];


### PR DESCRIPTION
From `https://aonsolutions.es/`

`aonsolutions.es##+js(trusted-set-cookie, cookies-consent, agree)`  was needed to get past the notice.

Safe to include the 'agree' and 'disagree', and its past tense  'agreed' and 'disagreed`