### PR TITLE
Fix Chartbeat flicker control div's

### DIFF
--- a/src/web_accessible_resources/chartbeat.js
+++ b/src/web_accessible_resources/chartbeat.js
@@ -27,4 +27,8 @@
         activity: noopfn,
         virtualPage: noopfn
     };
+    const flickerElm = document.querySelector('[id^=chartbeat-flicker-control]')
+    if (flickerElm) {
+        flickerElm.parentNode.removeChild(flickerElm)
+    }
 })();


### PR DESCRIPTION
Chartbeat is using "hide the screen for a few sec, until the script loads"

https://publicwww.com/websites/%22chartbeat-flicker-control-style%22/

As seen on https://www.politico.com/  https://www.welt.de/ https://www.rottentomatoes.com/

```
<style type="text/css" id="chartbeat-flicker-control-style">body { visibility: hidden !important; }</style><script type="text/javascript">
(function() {
var _sf_async_config = window._sf_async_config = (window._sf_async_config || {});
_sf_async_config.uid = 33430;
_sf_async_config.domain = 'www.politico.com';
_sf_async_config.useCanonical = true;
window.setTimeout(function() {
    var hider = document.getElementById('chartbeat-flicker-control-style');
    if (hider) {
        hider.parentNode.removeChild(hider);
    }
}, 1000);
})();</script>
<script src="//static.chartbeat.com/js/chartbeat_mab.js"></script>
```

Alternative version: 

```
(function() {
    'use strict';
    const noopfn = function() {
    };
    window.pSUPERFLY = {
        activity: noopfn,
        virtualPage: noopfn
    };
    const flickerElm = document.querySelector('[id^=chartbeat-flicker-control]')
    if (flickerElm) {
        const replacementElm = document.createElement(flickerElm.tagName)
        for (const attrName of ['id', 'type', 'className']) {
            if (flickerElm[attrName]) {
                replacementElm[attrName] = flickerElm[attrName]
            }
        }
        flickerElm.replaceWith(replacementElm)
    }
})()
```