### PR TITLE
Add accept/reject to local-storage

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -1047,6 +1047,8 @@ function setLocalStorageItemFn(
         'false', 'true',
         'on', 'off',
         'yes', 'no',
+        'accept', 'reject',
+        'accepted', 'rejected',
         '{}', '[]', '""',
         '$remove$',
     ];


### PR DESCRIPTION
From: https://temporal.io/


From the site `accepted`, `rejected` in set local storage.

Also added the singular `accept` and `reject` (not from this site).