### PR TITLE
Add Approved/disapproved to set-cookie

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3771,6 +3771,7 @@ function setCookie(
         'true', 't', 'false', 'f',
         'yes', 'y', 'no', 'n',
         'necessary', 'required',
+        'approved', 'disapproved',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);


### PR DESCRIPTION
From https://tibber.com/en

approved is used for  `tibber.com##+js(set-cookie, tibber_cc_essential, approved)`  

Disapproved isn't used on the site, no harm adding the negative to approved?