### PR TITLE
Add hide and hidden to set-cookie

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3785,6 +3785,7 @@ function setCookie(
         'yes', 'y', 'no', 'n',
         'necessary', 'required',
         'approved', 'disapproved',
+        'hide', 'hidden',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);


### PR DESCRIPTION
From https://mobian.dev/

Closing cookie banner sets cookie to `hide`, also added `hidden` as another valid cookie option.