### PR TITLE
Add essential and nonessential to set-cookie

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3791,6 +3791,7 @@ function setCookie(
         'necessary', 'required',
         'approved', 'disapproved',
         'hide', 'hidden',
+        'essential', 'nonessential',
     ];
     const normalized = value.toLowerCase();
     const match = /^("?)(.+)\1$/.exec(normalized);


### PR DESCRIPTION
From a request on https://github.com/easylist/easylist/issues/19266  Using essential value for a cookie value.

From; `fruugo.cz##+js(set-cookie, consents, essential)` also added the negative `nonessential` as an option.