### PR TITLE
Switch to updated Icelandic ABP List

### DIFF
--- a/assets/assets.dev.json
+++ b/assets/assets.dev.json
@@ -681,8 +681,8 @@
 		"title": "🇮🇸is: Icelandic ABP List",
 		"tags": "ads icelandic",
 		"lang": "is",
-		"contentURL": "https://adblock.gardar.net/is.abp.txt",
-		"supportURL": "https://adblock.gardar.net/"
+		"contentURL": "https://raw.githubusercontent.com/brave/adblock-lists/master/custom/is.txt",
+		"supportURL": "https://github.com/brave/adblock-lists/issues"
 	},
 	"ISR-0": {
 		"content": "filters",

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -681,8 +681,8 @@
 		"title": "🇮🇸is: Icelandic ABP List",
 		"tags": "ads icelandic",
 		"lang": "is",
-		"contentURL": "https://adblock.gardar.net/is.abp.txt",
-		"supportURL": "https://adblock.gardar.net/"
+		"contentURL": "https://raw.githubusercontent.com/brave/adblock-lists/master/custom/is.txt",
+		"supportURL": "https://github.com/brave/adblock-lists/issues"
 	},
 	"ISR-0": {
 		"content": "filters",


### PR DESCRIPTION
- We've had reports of missing ads by our users, and since the list hasn't been updated for 2 years. We forked the list to support them 
- Also we issues with the webhost `adblock.gardar.net`, the website will be occasionaly unavailable to check for updates, sure not that important that the list wasn't being updated. tldr the web host wasn't reliable, and kept spewing errors.

Was forked and have updated the domains and rules, removed the dead domains. The icelandic list will be updated and supported going forward.  We've already migrated away from the `adblock.gardar.net` list: https://github.com/brave/adblock-resources/pull/189  https://github.com/brave/adblock-lists/pull/1841

