### PR TITLE
Maintenance for the Serbo-Croatian Filters section

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -622,9 +622,13 @@
 		"group": "regions",
 		"off": true,
 		"title": "🇭🇷hr 🇷🇸rs: Dandelion Sprout's Serbo-Croatian filters",
-		"tags": "ads croatian serbian",
-		"lang": "hr sr",
+		"tags": "ads croatian serbian bosnian",
+		"lang": "bs hr sr",
 		"contentURL": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SerboCroatianList.txt",
+		"cdnURLs": [
+			"https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/SerboCroatianList.txt",
+			"https://cdn.statically.io/gl/DandelionSprout/adfilt/master/SerboCroatianList.txt"
+		],
 		"supportURL": "https://github.com/DandelionSprout/adfilt#readme"
 	},
 	"HUN-0": {

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -624,8 +624,8 @@
 		"title": "🇭🇷hr 🇷🇸rs: Dandelion Sprout's Serbo-Croatian filters",
 		"tags": "ads croatian serbian bosnian",
 		"lang": "bs hr sr",
-		"contentURL": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SerboCroatianList.txt",
-		"cdnURLs": [
+		"contentURL": [
+			"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SerboCroatianList.txt",
 			"https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/SerboCroatianList.txt",
 			"https://cdn.statically.io/gl/DandelionSprout/adfilt/master/SerboCroatianList.txt"
 		],
@@ -782,9 +782,7 @@
 		"tags": "ads norwegian danish icelandic",
 		"lang": "nb nn no da is",
 		"contentURL": [
-			"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt"
-		],
-		"cdnURLs": [
+			"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
 			"https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/NorwegianList.txt",
 			"https://cdn.statically.io/gl/DandelionSprout/adfilt/master/NorwegianList.txt"
 		],


### PR DESCRIPTION
- Added 2 CDNs, one of which lead to GitLab as is the case for Nordic Filters (Last night's temporary takedown for a few hours of the AdGuardFilters GitHub repo, made me extra aware of the need for non-GitHub backup hostings).
- Firefox's download pages list Bosnian as a distinct option, so I added their download page's ISO code for Bosnian to the "lang" values.

While I remember it's been wished for before to make threads for it in uBlock-issues instead of PRs, to make more people able to comment on suggested changes of mine, this one should on paper be simple enough to not need such a thread… I think.