### PR TITLE
Add negative 1 value

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -1009,6 +1009,7 @@ function getSafeCookieValuesFn() {
         'on', 'off',
         'true', 't', 'false', 'f',
         'yes', 'y', 'no', 'n',
+        '-1',
     ];
 }
 


### PR DESCRIPTION
From https://github.com/AdguardTeam/AdguardFilters/commit/5697ba449ddb85914f4388b7229cb0702742855e

There could be 2 ways of fixing this, include negative values or this way. Happy with either option tbh.

```
! reject
gdh.digital##+js(set-local-storage-item, cookie_accepted, -1)
```
