### PR TITLE
Add granted and done cookie values

### DIFF
--- a/src/js/resources/cookie.js
+++ b/src/js/resources/cookie.js
@@ -45,6 +45,7 @@ export function getSafeCookieValuesFn() {
         'true', 't', 'false', 'f',
         'yes', 'y', 'no', 'n',
         'all', 'none', 'functional',
+        'granted', 'done',
     ];
 }
 registerScriptlet(getSafeCookieValuesFn, {


### PR DESCRIPTION
Fixing login modal popup on https://trucksbook.eu/company/201882

Site is using granted/done consent values 

```
trucksbook.eu##+js(set-cookie, consent, done)
trucksbook.eu##+js(set-cookie, cookie_preferences, granted)
trucksbook.eu##+js(set-cookie, cookie_3rdparty, denied)
trucksbook.eu##+js(set-cookie, cookie_analytics, denied)
```