### PR TITLE
Performance improvement for scriptlets/dom-inspector.js

### DIFF
--- a/src/js/scriptlets/dom-inspector.js
+++ b/src/js/scriptlets/dom-inspector.js
@@ -152,7 +152,7 @@ const domLayout = (( ) => {
                 continue;
             }
             // sibling
-            if ( node instanceof Element ) {
+            if ( node.nodeType === 1 ) {
                 if ( node.nextElementSibling === null ) {
                     do {
                         node = stack.pop();


### PR DESCRIPTION
I noticed that I should have used `node.nodeType === 1` instead of `node instanceof Element` in part of https://github.com/gorhill/uBlock/pull/3857. This should be faster