### PR TITLE
Add Anti-AI Suggestions list

### DIFF
--- a/assets/assets.dev.json
+++ b/assets/assets.dev.json
@@ -471,6 +471,17 @@
 		],
 		"supportURL": "https://github.com/easylist/easylist#fanboy-lists"
 	},
+        "fanboy-ai-suggestions": {
+                "content": "filters",
+                "group": "annoyances",
+                "parent": "EasyList – Annoyances",
+                "off": true,
+                "title": "EasyList – Anti AI Suggestions",
+                "tags": "annoyances",
+                "preferred": true,
+                "contentURL": "https://raw.githubusercontent.com/easylist/easylist/refs/heads/master/fanboy-addon/fanboy_ai_suggestions.txt",
+                "supportURL": "https://github.com/easylist/easylist#fanboy-lists"
+        }, 
 	"easylist-newsletters": {
 		"content": "filters",
 		"group": "annoyances",

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -471,6 +471,17 @@
 		],
 		"supportURL": "https://github.com/easylist/easylist#fanboy-lists"
 	},
+        "fanboy-ai-suggestions": {
+                "content": "filters",
+                "group": "annoyances",
+                "parent": "EasyList – Annoyances",
+                "off": true,
+                "title": "EasyList – Anti AI Suggestions",
+                "tags": "annoyances",
+                "preferred": true,
+                "contentURL": "https://raw.githubusercontent.com/easylist/easylist/refs/heads/master/fanboy-addon/fanboy_ai_suggestions.txt",
+                "supportURL": "https://github.com/easylist/easylist#fanboy-lists"
+        },
 	"easylist-newsletters": {
 		"content": "filters",
 		"group": "annoyances",


### PR DESCRIPTION
Fixes complaints of AI buttons/divs/suggestions/nags by users:

- https://old.reddit.com/r/uBlockOrigin/search?q=rufus&restrict_sr=on&sort=relevance&t=all
- https://old.reddit.com/r/uBlockOrigin/search?q=AI&restrict_sr=on&sort=relevance&t=all

Already included in Brave: https://github.com/brave/adblock-resources/pull/271 (27 August)
