### PR TITLE
Applied the "#fff" shorthand to "#ffffff" instances in the uBO SVG logo to slightly reduce filespace.

### DIFF
--- a/src/img/ublock.svg
+++ b/src/img/ublock.svg
@@ -13,14 +13,14 @@
   <g
      style="display:inline;opacity:1">
     <g
-       style="fill:#800000;fill-opacity:1;stroke:#ffffff;stroke-width:1.62100744;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       style="fill:#800000;fill-opacity:1;stroke:#fff;stroke-width:1.62100744;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
        transform="matrix(0.6778654,0,0,0.56141828,-241.07537,-247.27712)" />
     <g
        transform="matrix(-0.6945203,0,0,0.56109687,375.02964,-247.42947)"
-       style="fill:#800000;fill-opacity:1;stroke:#ffffff;stroke-width:1.60191178000000001;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;stroke-linejoin:round">
+       style="fill:#800000;fill-opacity:1;stroke:#fff;stroke-width:1.60191178000000001;stroke-linecap:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;stroke-linejoin:round">
       <path
          d="m 447.83376,669.09921 c -80.63119,-57.03115 -80.63119,-57.03115 -80.63119,-199.60903 34.55623,0 46.07497,0 80.63119,-28.51558 m 0,228.12461 c 80.6312,-57.03115 80.6312,-57.03115 80.6312,-199.60903 -34.55623,0 -46.07497,0 -80.6312,-28.51558"
-         style="fill:#800000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.60191178;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+         style="fill:#800000;fill-opacity:1;fill-rule:nonzero;stroke:#fff;stroke-width:1.60191178;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
   </g>
   <g
@@ -32,13 +32,13 @@
        rx="11.999999"
        cy="81.325356"
        cx="102.12254"
-       style="fill:none;stroke:#ffffff;stroke-width:5.99999952;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;" />
+       style="fill:none;stroke:#fff;stroke-width:5.99999952;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;" />
     <g
-       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999996999999996;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#fff;fill-opacity:1;stroke:#fff;stroke-width:1.99999996999999996;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
        transform="scale(1.0018026,0.99820067)">
       <path
          d="m 81.72523,81.471945 c 0,11.019828 -4.991003,16.028841 -15.97121,16.028841 -10.980207,0 -15.97121,-5.009013 -15.97121,-16.028841 l 0,-24.043262 7.985605,0 0,24.043262 c 0,7.012618 0.9982,8.014421 7.985605,8.014421 6.987404,0 7.985605,-1.001803 7.985605,-8.014421 l 0,-24.043262 7.985605,0 z"
-         style="fill:#ffffff;stroke:#ffffff;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;" />
+         style="fill:#fff;stroke:#fff;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
There were 7 instances of `#ffffff` in `ublock.svg`, so I changed them to the official CSS shorthand `#fff`. This will reduce the file's size by 21 characters.

If you were to wish for a corresponding thread to be created in uBlock-issues, I could've made one on request.