### PR TITLE
fix: populate AdError.ErrorCode and AdError.Type enums

### DIFF
--- a/src/web_accessible_resources/google-ima.js
+++ b/src/web_accessible_resources/google-ima.js
@@ -467,8 +467,14 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
       return `AdError ${this.errorCode}: ${this.message}`;
     }
   }
-  AdError.ErrorCode = {};
-  AdError.Type = {};
+
+  AdError.ErrorCode = {
+    AUTOPLAY_DISALLOWED: 1205,
+  };
+  AdError.Type = {
+    AD_LOAD: "adLoadError",
+    AD_PLAY: "adPlayError",
+  };
 
   const isEngadget = () => {
     try {


### PR DESCRIPTION
AdError.ErrorCode and AdError.Type were exported as empty objects,
causing enum-based comparisons against shim-emitted errors to fail.

Add AUTOPLAY_DISALLOWED (1205) to ErrorCode, matching the error code
already dispatched in requestAds(). Add AD_LOAD and AD_PLAY to Type,
completing the two-member enum per the official HTML5 IMA SDK reference.

Raw value comparisons (e.g. === 1205) were unaffected. Only sites
branching on google.ima.AdError.ErrorCode.AUTOPLAY_DISALLOWED or
google.ima.AdError.Type.AD_PLAY benefit from this change.