### PR TITLE
[mv3] Discard DNR rules with conditions not supported by browser [uBOL-home Issue #715]

### DIFF
--- a/platform/mv3/extension/js/ruleset-manager.js
+++ b/platform/mv3/extension/js/ruleset-manager.js
@@ -132,6 +132,31 @@ pruneInvalidRegexRules.validated = new Map();
 
 /******************************************************************************/
 
+// A rule with a condition property unknown to the browser -- typically a
+// newer DNR feature such as `topDomains` -- causes updateDynamicRules() to
+// reject ALL rules in the same call, unlike in static rulesets where such
+// rules are individually ignored. Discard the offending rules and retry.
+
+const reUnexpectedProperty = /Unexpected property[: ]+["']?(\w+)/;
+
+async function updateDynamicRulesWithRetry(ruleUpdate) {
+    try {
+        return await dnr.updateDynamicRules(ruleUpdate);
+    } catch(reason) {
+        const prop = reUnexpectedProperty.exec(`${reason}`)?.[1] ?? '';
+        const kept = ruleUpdate.addRules?.filter(rule =>
+            rule.condition?.[prop] === undefined
+        ) ?? [];
+        // A retry must shrink addRules, lest the same rejection repeats
+        if ( kept.length === (ruleUpdate.addRules?.length ?? 0) ) { throw reason; }
+        ubolLog(`Dropped ${ruleUpdate.addRules.length - kept.length} DNR rules with unsupported condition '${prop}'`);
+        ruleUpdate.addRules = kept;
+        return updateDynamicRulesWithRetry(ruleUpdate);
+    }
+}
+
+/******************************************************************************/
+
 async function getDynamicRegexRuleCount() {
     const rules = await dnr.getDynamicRules();
     const regexRules = rules.filter(a => Boolean(a.condition?.regexFilter));
@@ -212,7 +237,7 @@ export async function updateDynamicAndSessionRules() {
     const response = {};
 
     try {
-        await dnr.updateDynamicRules({ addRules, removeRuleIds });
+        await updateDynamicRulesWithRetry({ addRules, removeRuleIds });
         if ( removeRuleIds.length !== 0 ) {
             ubolLog(`Remove ${removeRuleIds.length} dynamic DNR rules`);
         }
@@ -755,7 +780,7 @@ async function updateUserRules() {
     // adding rules.
     try {
         await dnr.updateDynamicRules({ removeRuleIds });
-        await dnr.updateDynamicRules({ addRules });
+        await updateDynamicRulesWithRetry({ addRules });
         if ( removeRuleIds.length !== 0 ) {
             ubolLog(`updateUserRules() / Removed ${removeRuleIds.length} dynamic DNR rules`);
         }


### PR DESCRIPTION
## UNNECCESARY NOW - Closed by gorhill/uBlock@993d42c

---

A rule carrying a condition property unknown to the browser -- such as `topDomains` on browsers not yet supporting it -- causes `updateDynamicRules()` to reject all rules in the same call, unlike in static rulesets where such rules are individually ignored.

May close [uBOL-home #715](https://github.com/uBlockOrigin/uBOL-home/issues/715)

One such rule compiled from a `top=` filter currently disables the entire regex-rules realm on affected browsers, and the same failure can empty the user-rules realm through imported lists or user DNR rules.

Discard the offending rules and retry, so they degrade the same way as their static ruleset counterparts.

<img width="2976" height="928" alt="screenshot-01" src="https://github.com/user-attachments/assets/c1a1da26-58e6-4024-ba67-47fceb6606ca" />