### PR TITLE
Allow subscribing to filter lists from other forges

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -57,7 +57,11 @@
         "https://filterlists.com/*",
         "https://forums.lanik.us/*",
         "https://github.com/*",
-        "https://*.github.io/*"
+        "https://*.github.io/*",
+        "https://gitlab.com/*",
+        "https://*.gitlab.io/*",
+        "https://codeberg.org/*",
+        "https://*.codeberg.page/*"
       ],
       "js": [
         "/js/scriptlets/subscriber.js"

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -74,7 +74,11 @@
         "https://filterlists.com/*",
         "https://forums.lanik.us/*",
         "https://github.com/*",
-        "https://*.github.io/*"
+        "https://*.github.io/*",
+        "https://gitlab.com/*",
+        "https://*.gitlab.io/*",
+        "https://codeberg.org/*",
+        "https://*.codeberg.page/*"
       ],
       "js": [
         "/js/scriptlets/subscriber.js"

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -57,7 +57,11 @@
         "https://filterlists.com/*",
         "https://forums.lanik.us/*",
         "https://github.com/*",
-        "https://*.github.io/*"
+        "https://*.github.io/*",
+        "https://gitlab.com/*",
+        "https://*.gitlab.io/*",
+        "https://codeberg.org/*",
+        "https://*.codeberg.page/*"
       ],
       "js": [
         "/js/scriptlets/subscriber.js"

--- a/platform/thunderbird/manifest.json
+++ b/platform/thunderbird/manifest.json
@@ -41,7 +41,11 @@
         "https://filterlists.com/*",
         "https://forums.lanik.us/*",
         "https://github.com/*",
-        "https://*.github.io/*"
+        "https://*.github.io/*",
+        "https://gitlab.com/*",
+        "https://*.gitlab.io/*",
+        "https://codeberg.org/*",
+        "https://*.codeberg.page/*"
       ],
       "js": [
         "/js/scriptlets/subscriber.js"


### PR DESCRIPTION
Many people, including myself, upload their custom filters to other forges that are not GitHub, notably GitLab and Codeberg. Unfortunately, subscribe links do not work there since uBlock Origin does not currently inject the subscriber code in those sites, forcing users to manually copy and paste the link.
Please consider merging this pull request to make subscribing to filter lists easier and more accessible from other forges.