### PR TITLE
Improve prevent-clipboard-write.js

### DIFF
--- a/src/js/resources/prevent-clipboard-write.js
+++ b/src/js/resources/prevent-clipboard-write.js
@@ -109,7 +109,9 @@ function preventClipboardWrite(needle = '') {
             const items = context.callArgs[0];
             if ( !Array.isArray(items) ) { return context.reflect(); }
             Promise.all(items.map(item =>
-                item.getType(item.types[0]).then(b => b.text())
+                item.types.length
+                    ? item.getType(item.types[0]).then(b => b.text())
+                    : Promise.resolve('')
             )).then(texts => {
                 const text = texts.join('\n');
                 if ( prevent(text) ) { return; }

--- a/src/js/resources/prevent-clipboard-write.js
+++ b/src/js/resources/prevent-clipboard-write.js
@@ -97,11 +97,27 @@ function preventClipboardWrite(needle = '') {
         return true;
     };
     const installTraps = ( ) => {
+        // navigator.clipboard.writeText()
         proxyApplyFn('navigator.clipboard.writeText', function(context) {
             const text = `${context.callArgs[0]}`;
             if ( prevent(text) ) { return; }
             return context.reflect();
         }, { skipToString: true });
+
+        // navigator.clipboard.write() — ClipboardItem based, only checks types[0]
+        proxyApplyFn('navigator.clipboard.write', function(context) {
+            const items = context.callArgs[0];
+            if ( !Array.isArray(items) ) { return context.reflect(); }
+            Promise.all(items.map(item =>
+                item.getType(item.types[0]).then(b => b.text())
+            )).then(texts => {
+                const text = texts.join('\n');
+                if ( prevent(text) ) { return; }
+                context.reflect();
+            }).catch(() => { context.reflect(); });
+        }, { skipToString: true });
+
+        // document.execCommand('copy' | 'cut')
         proxyApplyFn('document.execCommand', function(context) {
             const { callArgs } = context;
             if ( callArgs[0] === 'copy' || callArgs[0] === 'cut' ) {


### PR DESCRIPTION
Add navigator.clipboard.write() coverage to prevent-clipboard-write

The current scriptlet covers navigator.clipboard.writeText() and document.execCommand('copy'|'cut') but leaves navigator.clipboard.write() unhandled. While ClickFix sites predominantly use writeText() today, clipboard.write() is the more capable API and a natural fallback for attackers looking to evade detection.

The proposed addition intercepts clipboard.write() inside the existing installTraps block, reads the first MIME type from each ClipboardItem (always text/plain for ClickFix payloads), and passes the extracted text through the existing prevent() function — so pattern matching, domAlert, and logging all behave identically to the writeText path. A .catch() is included to ensure context.reflect() is called on any blob read failure, avoiding silent clipboard breakage on legitimate sites.